### PR TITLE
Chore(doc): bump the minimum version of k8s from 1.15 to 1.18

### DIFF
--- a/docs/getting-started/quick-install.mdx
+++ b/docs/getting-started/quick-install.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 ## 1. Choose Control Plane Cluster
 
 Requirements:
-- Kubernetes cluster >= v1.15.0
+- Kubernetes cluster >= v1.18.0
 - `kubectl` installed and configured
 
 KubeVela relies on Kubernetes as control plane. The control plane could be any managed Kubernetes offering or your own cluster. The only requirement is please ensure [ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/) is installed and enabled.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-install.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/getting-started/quick-install.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 ## 1. 选择放置控制平面的集群
 
 确保:
-- Kubernetes 集群版本 >= v1.15.0
+- Kubernetes 集群版本 >= v1.18.0
 - 安装并配置 kubectl 命令行工具
 
 KubeVela 得以成为控制平面，主要是依赖 Kubernetes 。它可以放置在任何托管 Kubernetes 作为底座的产品或你自己的集群中。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/getting-started/install.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/getting-started/install.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 ## 1. 设置 Kubernetes 集群
 
 要求:
-- Kubernetes 集群版本 >= v1.15.0
+- Kubernetes 集群版本 >= v1.18.0
 - 安装并配置 kubectl
 
 KubeVela是一个简单的自定义控制器，可以安装在任何 Kubernetes 集群上，包括托管产品或你自己的集群。唯一的要求是请确保已安装并启用了 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/)。

--- a/versioned_docs/version-v1.1/install.mdx
+++ b/versioned_docs/version-v1.1/install.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 ## 1. Choose Control Plane Cluster
 
 Requirements:
-- Kubernetes cluster >= v1.15.0
+- Kubernetes cluster >= v1.18.0
 - `kubectl` installed and configured
 
 KubeVela relies on Kubernetes as control plane. The control plane could be any managed Kubernetes offering or your own cluster. The only requirement is please ensure [ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/) is installed and enabled.


### PR DESCRIPTION
Bump the minimum version of k8s cluster from 1.15 to 1.18.

Fix: oam-dev/kubevela#1998

/cc @wonderflow 