### PR TITLE
Fix: addon terraform isn't installed by default

### DIFF
--- a/docs/platform-engineers/advanced-install.mdx
+++ b/docs/platform-engineers/advanced-install.mdx
@@ -144,7 +144,7 @@ helm upgrade --install --create-namespace --namespace vela-system  kubevela kube
 
 | Name                  | Description                                             | capability        | Open Source Project Reference                                        |
 |---------------------|-------------------------------------------------|----------------|-------------------------------------------------|
-| terraform           | Basic addon to Provide Cloud Resources(installed by default)                                    | -              | https://github.com/oam-dev/terraform-controller |
+| terraform           | Basic addon to Provide Cloud Resources                                    | -              | https://github.com/oam-dev/terraform-controller |
 | fluxcd              | Support Deployment of Helm and Kustomize components                       | kustomize、helm | https://fluxcd.io/                              |
 | kruise              | Support more powerful workload feature                     | cloneset       | https://openkruise.io/                          |
 | prometheus          | Support basic observability from Promethus                           | -              | https://prometheus.io/                          |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/platform-engineers/advanced-install.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/platform-engineers/advanced-install.mdx
@@ -163,7 +163,7 @@ v1alpha1.cluster.core.oam.dev   vela-system/kubevela-cluster-gateway-service   T
 
 | 插件                  | 简介                                              | 对应的内置功能        | 插件对应开源项目                                        |
 |---------------------|-------------------------------------------------|----------------|-------------------------------------------------|
-| terraform           | 提供云资源（默认已安装）                                    | -              | https://github.com/oam-dev/terraform-controller |
+| terraform           | 提供云资源                                    | -              | https://github.com/oam-dev/terraform-controller |
 | fluxcd              | 提供 Helm、Kustomize 组件的部署功能                       | kustomize、helm | https://fluxcd.io/                              |
 | kruise              | 提供比 Kubernetes 原生更强大的工作负载套件                     | cloneset       | https://openkruise.io/                          |
 | prometheus          | 提供基于 Promethus 的基础监控功能                          | -              | https://prometheus.io/                          |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/platform-engineers/advanced-install.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.1/platform-engineers/advanced-install.mdx
@@ -163,7 +163,7 @@ v1alpha1.cluster.core.oam.dev   vela-system/kubevela-cluster-gateway-service   T
 
 | 插件                  | 简介                                              | 对应的内置功能        | 插件对应开源项目                                        |
 |---------------------|-------------------------------------------------|----------------|-------------------------------------------------|
-| terraform           | 提供云资源（默认已安装）                                    | -              | https://github.com/oam-dev/terraform-controller |
+| terraform           | 提供云资源                                    | -              | https://github.com/oam-dev/terraform-controller |
 | fluxcd              | 提供 Helm、Kustomize 组件的部署功能                       | kustomize、helm | https://fluxcd.io/                              |
 | kruise              | 提供比 Kubernetes 原生更强大的工作负载套件                     | cloneset       | https://openkruise.io/                          |
 | prometheus          | 提供基于 Promethus 的基础监控功能                          | -              | https://prometheus.io/                          |

--- a/versioned_docs/version-v1.1/platform-engineers/advanced-install.mdx
+++ b/versioned_docs/version-v1.1/platform-engineers/advanced-install.mdx
@@ -144,7 +144,7 @@ helm upgrade --install --create-namespace --namespace vela-system  kubevela kube
 
 | Name                  | Description                                             | capability        | Open Source Project Reference                                        |
 |---------------------|-------------------------------------------------|----------------|-------------------------------------------------|
-| terraform           | Basic addon to Provide Cloud Resources(installed by default)                                    | -              | https://github.com/oam-dev/terraform-controller |
+| terraform           | Basic addon to Provide Cloud Resources                                    | -              | https://github.com/oam-dev/terraform-controller |
 | fluxcd              | Support Deployment of Helm and Kustomize components                       | kustomize、helm | https://fluxcd.io/                              |
 | kruise              | Support more powerful workload feature                     | cloneset       | https://openkruise.io/                          |
 | prometheus          | Support basic observability from Promethus                           | -              | https://prometheus.io/                          |


### PR DESCRIPTION
Update the docs in v1.1 and the current version