### PR TITLE
fix(install): window extract file missing ext error

### DIFF
--- a/static/script/install.ps1
+++ b/static/script/install.ps1
@@ -12,6 +12,7 @@ $ErrorActionPreference = 'stop'
 $VelaRoot = $VelaRoot -replace ' ', '` '
 
 # Constants
+$VelaCliBuildName = "vela"
 $VelaCliFileName = "vela.exe"
 $VelaCliFilePath = "${VelaRoot}\${VelaCliFileName}"
 
@@ -88,7 +89,7 @@ if (!(Test-Path $zipFilePath -PathType Leaf)) {
 # Extract KubeVela CLI to $VelaRoot
 Write-Output "Extracting $zipFilePath..."
 Microsoft.Powershell.Archive\Expand-Archive -Force -Path $zipFilePath -DestinationPath $VelaRoot
-$ExtractedVelaCliFilePath = "${VelaRoot}\${os_arch}\${VelaCliFileName}"
+$ExtractedVelaCliFilePath = "${VelaRoot}\${os_arch}\${VelaCliBuildName}"
 Copy-Item $ExtractedVelaCliFilePath -Destination $VelaCliFilePath
 if (!(Test-Path $VelaCliFilePath -PathType Leaf)) {
     throw "Failed to extract Vela Cli archive - $zipFilePath"


### PR DESCRIPTION
修复在`Windows PowerShell`下安装错误，错误信息如下：
```
Creating c:\vela directory
Downloading https://api.github.com/repos/oam-dev/kubevela/releases/assets/52242881 ...
Extracting c:\vela\vela-v1.2.0-beta.3-windows-amd64.zip...
Copy-Item : 找不到路径“C:\vela\windows-amd64\vela.exe”，因为该路径不存在。
  所在位置 行:92 字符: 1
  + Copy-Item $ExtractedVelaCliFilePath -Destination $VelaCliFilePath
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\vela\windows-amd64\vela.exe:String) [Copy-Item], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.CopyItemCommand
```

修复后安装正常：
```
Installing Vela...
Creating c:\vela directory
Downloading https://api.github.com/repos/oam-dev/kubevela/releases/assets/52242881 ...
Extracting c:\vela\vela-v1.2.0-beta.3-windows-amd64.zip...
A Highly Extensible Platform Engine based on Kubernetes and Open Application Model.

Usage:
  vela [flags]
  vela [command]
...
```