### PR TITLE
update version of k8s for kind installation

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -99,7 +99,7 @@ Follow [this guide](https://kind.sigs.k8s.io/docs/user/quick-start/#installation
 Then spins up a kind cluster:
 
 ```shell script
-cat <<EOF | kind create cluster --image=kindest/node:v1.18.15 --config=-
+cat <<EOF | kind create cluster --image=kindest/node:v1.20.7 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:


### PR DESCRIPTION
In the kind documentation, the version of k8s installed does not fall
within the version recommendations from the same page

`cluster >= v1.19 && < v1.22`

Version `v1.18.15` also causes the ingress controller installation to fail
with version compatibility errors.

This patch updates the version to the highest current version of 1.22.