### PR TITLE
Update install.mdx—change header number.

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -229,7 +229,7 @@ sudo mv ./vela /usr/local/bin/vela
 </TabItem>
 </Tabs>
 
-## 2. Install KubeVela Core
+## 3. Install KubeVela Core
 
 <Tabs
     className="unique-tabs"


### PR DESCRIPTION
Small change, but there was a typo in the instruction. Install KubeVela Core should be ## 3, not ## 2 again.

Signed-off-by: Excel Chukwu excel.chukwu1.0@gmail.com