### PR TITLE
Add link off installing addon offline

### DIFF
--- a/docs/platform-engineers/system-operation/offline-installation.md
+++ b/docs/platform-engineers/system-operation/offline-installation.md
@@ -57,3 +57,4 @@ repository after you pushed the package into the repository.
 
 ## Addon
 
+Please refer to [Enable Addon without Internet Access](./enable-addon-offline.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/current/platform-engineers/system-operation/offline-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/platform-engineers/system-operation/offline-installation.md
@@ -58,3 +58,5 @@ charts/vela-core/templates/defwithtemplate/nocalhost.yaml:        						image: "
 
 
 ## KubeVela Addon 离线部署
+
+请查看[插件的离线安装](./enable-addon-offline.md).

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/platform-engineers/system-operation/offline-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3/platform-engineers/system-operation/offline-installation.md
@@ -58,3 +58,5 @@ charts/vela-core/templates/defwithtemplate/nocalhost.yaml:        						image: "
 
 
 ## KubeVela Addon 离线部署
+
+请查看[插件的离线安装](./enable-addon-offline.md).

--- a/versioned_docs/version-v1.3/platform-engineers/system-operation/offline-installation.md
+++ b/versioned_docs/version-v1.3/platform-engineers/system-operation/offline-installation.md
@@ -57,3 +57,4 @@ repository after you pushed the package into the repository.
 
 ## Addon
 
+Please refer to [Enable Addon without Internet Access](./enable-addon-offline.md).


### PR DESCRIPTION
In the offline installation of KubeVela doc, added a link of how
to install addon.

Signed-off-by: Zheng Xi Zhou <zzxwill@gmail.com>
