### PR TITLE
Update install.mdx for k8s cluster of type Kind 

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -144,12 +144,6 @@ nodes:
 EOF
 ```
 
-Install ingress controller to enable service route：
-
-```shell script
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
-```
-
 </TabItem>
 
 <TabItem value="cloudprovider">


### PR DESCRIPTION
For the clusters which are created by `kind` , there is no need to install the ingress-controller, since the installation of vela core and vela ux does not has ingress resource need to be created.