### PR TITLE
Fix a bug in the definition of the helm application example

### DIFF
--- a/docs/tutorials/helm.md
+++ b/docs/tutorials/helm.md
@@ -35,7 +35,7 @@ When the addon is `enabled`, it means that it's ready to. You can start to deplo
 You can also enable the addon via CLI:
 
 ```shell
-vale addon enable fluxcd
+vela addon enable fluxcd
 ```
 
 ## Creating Redis application
@@ -79,8 +79,12 @@ spec:
         chart: "redis"
         version: "16.8.5"
         values: 
-          master.persistence.size: 16Gi
-          replica.persistence.size: 16Gi
+          master:
+            persistence:
+              size: 16Gi
+          replica:
+            persistence:
+              size: 16Gi
 ```
 
 Deploy this application：

--- a/versioned_docs/version-v1.3/tutorials/helm.md
+++ b/versioned_docs/version-v1.3/tutorials/helm.md
@@ -35,7 +35,7 @@ When the addon is `enabled`, it means that it's ready to. You can start to deplo
 You can also enable the addon via CLI:
 
 ```shell
-vale addon enable fluxcd
+vela addon enable fluxcd
 ```
 
 ## Creating Redis application
@@ -79,8 +79,12 @@ spec:
         chart: "redis"
         version: "16.8.5"
         values: 
-          master.persistence.size: 16Gi
-          replica.persistence.size: 16Gi
+          master:
+            persistence:
+              size: 16Gi
+          replica:
+            persistence:
+              size: 16Gi
 ```
 
 Deploy this application：

--- a/versioned_docs/version-v1.3/tutorials/helm.md
+++ b/versioned_docs/version-v1.3/tutorials/helm.md
@@ -35,7 +35,7 @@ When the addon is `enabled`, it means that it's ready to. You can start to deplo
 You can also enable the addon via CLI:
 
 ```shell
-vela addon enable fluxcd
+vale addon enable fluxcd
 ```
 
 ## Creating Redis application
@@ -79,12 +79,8 @@ spec:
         chart: "redis"
         version: "16.8.5"
         values: 
-          master:
-            persistence:
-              size: 16Gi
-          replica:
-            persistence:
-              size: 16Gi
+          master.persistence.size: 16Gi
+          replica.persistence.size: 16Gi
 ```
 
 Deploy this application：


### PR DESCRIPTION
### Changes

- Fix a typo in vela command
```
vela addon enable fluxcd
```

- Update application helm example to fix parameters definition
When deploying the previous application, we check the generated statefulset and see that the resources do not have the defined size.

```
...
spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 8Gi
      volumeMode: Filesystem
...
```
instead, if we deploy the following definition:

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: helm-redis
spec:
  components:
    - name: redis
      type: helm
      properties:
        repoType: "helm"
        url: "https://charts.bitnami.com/bitnami"
        chart: "redis"
        version: "16.8.5"
        values: 
          master:
            persistence:
              size: 16Gi
          replica:
            persistence:
              size: 16Gi
```
the statefulset has the resources defined 
```
  spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 16Gi
      volumeMode: Filesystem
```