### PR TITLE
Fix: port-forward to 8000 avoid conflict with velad

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -92,7 +92,7 @@ Addon: velaux enabled Successfully.
 By default, velaux didn't have any exposed port, you can view it by:
 
 ```
-vela port-forward addon-velaux -n vela-system 8080:80
+vela port-forward addon-velaux -n vela-system 8000:80
 ```
 
 Choose `> Cluster: local | Namespace: vela-system | Component: velaux | Kind: Service` for visit.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -182,7 +182,7 @@ After finished [the installation of VelaUX](./install#2-install-velaux), you can
 * Port forward the UI if you don't have endpoint for access:
 
 ```
-vela port-forward addon-velaux -n vela-system 8080:80
+vela port-forward addon-velaux -n vela-system 8000:80
 ```
 
 * Check the password by:


### PR DESCRIPTION
VelaD will listen to 8080 by default. It'll be better to change port-forward host port to another port. 

In this PR, it is changed to 8000.