### PR TITLE
Fix: resolve static files not being built

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,7 +57,8 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
           yarn add nodejieba
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --production=false
+          yarn build
       - name: Install ossutil
         run: wget http://gosspublic.alicdn.com/ossutil/1.7.0/ossutil64 && chmod +x ossutil64 && mv ossutil64 ossutil
       - name: Configure Alibaba Cloud OSSUTIL


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

Apparently, this workflow is broken:
<img width="490" alt="image" src="https://user-images.githubusercontent.com/55270174/174949595-3e336842-cf45-42ca-bbd5-9bda93b88188.png">

This is caused by this commit (removed the build commands): https://github.com/kubevela/kubevela.io/commit/0c33aa3bd9887c8f683d6cfb31b63b57c179af07

This pr restores build commands.
