### PR TITLE
translate reference/addons into Chinese

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/cert-manager.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/cert-manager.md
@@ -1,18 +1,18 @@
 ---
-title: Cert-manager
+title: 证书管理器
 ---
 
-This addon is for cert-manager, which is managing the kubernetes certificates.
+证书管理器插件提供了 kubernetes 证书管理的功能。
 
-Install the certificate manager on your Kubernetes cluster to enable adding the webhook component (only needed once per Kubernetes cluster).
+在你的 kubernetes 集群中安装证书管理器以添加这个 webhook 组件（仅需要在每个集群中运行一次）。
 
-## Install
+## 安装插件
 
 ```shell
 vela addon enable cert-manager
 ```
 
-## Uninstall
+## 卸载插件
 
 ```shell
 vela addon disable cert-manager

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/dex.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/dex.md
@@ -1,21 +1,20 @@
 ---
-title: dex
+title: Dex
 ---
 
-This addon provides dex login for VelaUX.
+这个插件为 VelaUX 提供了 Dex 登录
 
-Dex is an identity service that uses [OpenID Connect](https://openid.net/connect/) to drive authentication for other apps.
-Dex acts as a portal to other identity providers through [“connectors.”](https://dexidp.io/docs/connectors/) This lets Dex defer authentication to LDAP servers, SAML providers, or established identity providers like GitHub, Google, and Active Directory. Clients write their authentication logic once to talk to Dex, then Dex handles the protocols for a given backend.
+Dex 是一种身份服务，它使用 [OpenID Connect](https://openid.net/connect/) 来为其他应用程序登录提供身份验证能力。 Dex 通过 “[connectors](https://dexidp.io/docs/connectors/)” 充当其他身份提供者的门户。 这允许 Dex 将身份验证推迟到 LDAP 服务器、SAML 提供者或已建立的身份提供者（如 GitHub、Google 和 Active Directory）。 客户端只需编写一次与 Dex 交互的身份验证逻辑，然后 Dex 处理 给定后端的协议。
 
-Please refer to [Dex website](https://dexidp.io/docs/) for more details.
+更多详情请参阅 [Dex 网站](https://dexidp.io/docs/)。
 
-## Install
+## 安装插件
 
 ```shell
 $ vela addon enable dex
 ```
 
-## Uninstall
+##  卸载插件
 
 ```shell
 $ vela addon uninstall dex

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/flink-kubernetes-operator.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/flink-kubernetes-operator.md
@@ -1,22 +1,22 @@
 # flink-kubernetes-operator
 
-A Kubernetes operator for Apache Flink(https://github.com/apache/flink-kubernetes-operator), it allows users to manage Flink applications and their lifecycle through native k8s tooling like kubectl.
+Apache Flink (https://github.com/apache/flink-kubernetes-operator) 的 Kubernetes operator，它允许用户通过 kubectl 等原生 k8s 工具来管理 Flink 应用程序及其生命周期。
 
-## Install
+## 安装插件
 
 ```shell
 vela addon enable flink-kubernetes-operator
 ```
 
-## Uninstall
+## 卸载插件
 
 ```shell
 vela addon disable flink-kubernetes-operator
 ```
 
-## Check the flink-kubernetes-operator running status
+## 检查 flink-kubernetes-operator 的运行状态
 
-Since this addon dependents `fluxcd` and `cert-manager` addon, so will enable them automatically. Check the status of them:
+由于这个插件依赖于`fluxcd`和`cert-manager`插件，所以会自动启用它们。执行下面的命令来检查它们的状态：
 ```shell
 $ vela ls -n vela-system
 APP                             COMPONENT               TYPE            TRAITS  PHASE   HEALTHY STATUS                                                          CREATED-TIME                 
@@ -30,8 +30,7 @@ addon-fluxcd                    flux-system-namespace   raw                     
 
 ```
 
-
- Show the component type `flink-cluster`, so we know how to use it in one application. As a flink user, you can choose the parameter to set for your flink cluster
+通过显示`flink-cluster`组件的字段类型，让我们知道如何在一个应用程序中使用它们。 作为 flink 用户，你可以选择它们作为你的 flink 集群的设置参数。
 ```shell
 vela show flink-cluster
 # Properties
@@ -54,12 +53,11 @@ vela show flink-cluster
 +--------------+-------------+--------+----------+---------------------------------------------------------------+
 ```
 
-## Example for how to run a component typed flink-cluster in application
+## 在应用中运行一个 flink-cluster 类型组件的示例
 
-First please make sure your cluster already exists namespace `flink-home`.
+首先请确保你的集群已经存在命名空间`flink-home`。
 
-Then deploy the application:
-
+然后部署下面的应用：
 ```shell
 cat <<EOF | vela up -f -
 apiVersion: core.oam.dev/v1beta1
@@ -76,7 +74,7 @@ components:
 EOF      
 ```
 
-Check all the related resources:
+检查相关资源的状态：
 
 ```shell
 vela status flink-app-v1 
@@ -108,4 +106,4 @@ Services:
   No trait applied
 ```
 
-You can see you first flink-cluster application is running!
+你会看到你的第一个 flink-cluster 应用已经处于运行状态了。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/kubevela-io.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/kubevela-io.md
@@ -1,26 +1,26 @@
 ---
-title: kubevela.io
+title: kubevela-io
 ---
 
-This addon is the document website, align with https://kubevela.io/ and its mirror https://kubevela.net/ .
+这个插件是一个文档网站，文档内容与 https://kubevela.io/ 及其镜像 https://kubevela.net/ 是同步更新的。
 
-Use this addon can help you to read the document in your cluster which can be air-gaped environment.
+使用此插件可以帮助你在集群中无缝查阅文档。
 
-## install
+## 安装插件
 
 ```shell
 vela addon enable kubevela-io
 ```
 
-## uninstall
+## 卸载插件
 
 ```shell
 vela addon disable kubevela-io
 ```
 
-## more notes
-- About the image to deploy
-    - The image in this addon is oam-dev/kubevela-io:latest in default. you can pull the image from the dockerhub or you can compile the source code and built it to an image, then push your own local hub.
-- About the way to access the local kubevela-io website
-    - You can use the NodePort service which is deployed in vela-system named kubevela-io-np
-    - You may use the ingress as you wish
+## 更多信息
+- 关于部署的镜像
+  - 此插件中使用的镜像默认为 oam-dev/kubevela-io:latest。 你可以从 dockerhub 拉取镜像，也可以编译源代码并将其构建为镜像，然后推送到你自己的本地镜像仓库。
+- 关于如何访问本地 kubevela-io 文档站点
+  - 你可以使用已经部署在 vela-system 命名空间里的名为 kubevela-io-np 的 NodePort 服务。
+  - 当然你也可以使用 ingress 来访问。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/ocm-gateway-manager-addon.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/ocm-gateway-manager-addon.md
@@ -2,31 +2,23 @@
 title: OCM Cluster-Gateway Manager
 ---
 
-__TL;DR__: "OCM Cluster-Gateway Manager" addon installs an operator component
-into the hub cluster that help the administrator to easily operate the
-configuration of cluster-gateway instances via "ClusterGatewayConfiguration"
-custom resource. *WARNING* this addon will restart the cluster-gateway
-instances upon the first-time installation.
+OCM Cluster-Gateway Manager 插件在管理集群中安装了一个 operator 组件，帮助管理员通过自定义资源 ClusterGatewayConfiguration 轻松操作集群网关实例的配置。 *警告*：此插件将在首次安装时重新启动集群网关实例。
 
-## What does "Cluster-Gateway Manager" do?
+## Cluster-Gateway Manager 可以做什么？
 
-Basically it helps us to sustainably operate the cluster-gateway instances from
-the following aspects:
+一般来说，它可以在以下几个方面来帮助我们：
 
-* Automatic cluster-gateway's server TLS certificate rotation.
-* Automatic cluster discovery.
-* Structurize the component configuration for cluster-gateway.
-* Manages the "egress identity" for cluster-gateway to access each clusters.
+* 自动轮换集群网关服务器的 TLS 证书。
+* 自动发现新集群。
+* 结构化集群网关的组件配置。
+* 管理集群网关访问每个集群的“出口认证”。
 
-Note that the requests proxied by cluster-gateway will use the identity of
-`open-cluster-management-managed-serviceaccount/cluster-gateway` to access
-the managed clusters, and by default w/ cluster-admin permission, so please
-be mindful of that.
+请注意，由 cluster-gateway 代理的请求将使用`open-cluster-management-managed-serviceaccount/cluster-gateway`的身份访问托管集群，并且默认情况下具有 cluster-admin 权限，因此请注意这一点。
 
 
-### How to confirm if the addon installation is working?
+###  如何确定插件是正常运转的？
 
-Run the following commands to check the healthiness of the addons:
+运行以下命令来检查插件的健康状况：
 
 ```shell
 $ kubectl -n <cluster> get managedclusteraddon
@@ -37,14 +29,13 @@ NAMESPACE   NAME                     AVAILABLE   DEGRADED   PROGRESSING
 <cluster>   managed-serviceaccount   True 
 ```
 
-In case you have too many clusters to browse at a time, install the command-line
-binary via:
+如果一次要浏览的集群太多，请通过下面的命令来安装二进制命令`clusteradm`：
 
 ```shell
 curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
 ```
 
-Then run the following commands to see the details of the addon:
+然后通过运行下面的命令来获取多集群插件状态：
 
 ```shell
 $ clusteradm get addon
@@ -72,10 +63,9 @@ $ clusteradm get addon
             └── ...
 ```
 
-### Sample of ClusterGatewayConfiguration API
+### ClusterGatewayConfiguration API 配置示例
 
-You can read or edit the overall configuration of cluster-gateway deployments
-via the following command:
+你可以通过以下命令来查看或编辑集群网关部署的整体配置信息：
 
 ```shell
 $ kubectl get clustergatewayconfiguration -o yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/ocm-hub-control-plane.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/ocm-hub-control-plane.md
@@ -2,31 +2,23 @@
 title: OCM Cluster-Gateway Manager
 ---
 
-__TL;DR__: "OCM Cluster-Gateway Manager" addon installs an operator component
-into the hub cluster that help the administrator to easily operate the
-configuration of cluster-gateway instances via "ClusterGatewayConfiguration"
-custom resource. *WARNING* this addon will restart the cluster-gateway
-instances upon the first-time installation.
+OCM Cluster-Gateway Manager 插件在管理集群中安装了一个 operator 组件，帮助管理员通过自定义资源 “ClusterGatewayConfiguration” 轻松操作集群网关实例的配置。 *警告*：此插件将在首次安装时重新启动集群网关实例。
 
-## What does "Cluster-Gateway Manager" do?
+## Cluster-Gateway Manager 可以做什么？
 
-Basically it helps us to sustainably operate the cluster-gateway instances from
-the following aspects:
+一般来说，它可以在以下几个方面来帮助我们：
 
-* Automatic cluster-gateway's server TLS certificate rotation.
-* Automatic cluster discovery.
-* Structurize the component configuration for cluster-gateway.
-* Manages the "egress identity" for cluster-gateway to access each clusters.
+* 自动轮换集群网关服务器的 TLS 证书。
+* 自动发现新集群。
+* 结构化集群网关的组件配置。
+* 管理集群网关访问每个集群的“出口认证”。
 
-Note that the requests proxied by cluster-gateway will use the identity of
-`open-cluster-management-managed-serviceaccount/cluster-gateway` to access
-the managed clusters, and by default w/ cluster-admin permission, so please
-be mindful of that.
+请注意，由 cluster-gateway 代理的请求将使用`open-cluster-management-managed-serviceaccount/cluster-gateway`的身份访问托管集群，并且默认情况下具有 cluster-admin 权限，因此请注意这一点。
 
 
-### How to confirm if the addon installation is working?
+###  如何确定插件是正常运转的？
 
-Run the following commands to check the healthiness of the addons:
+运行以下命令来检查插件的健康状况：
 
 ```shell
 $ kubectl -n <cluster> get managedclusteraddon
@@ -37,14 +29,13 @@ NAMESPACE   NAME                     AVAILABLE   DEGRADED   PROGRESSING
 <cluster>   managed-serviceaccount   True 
 ```
 
-In case you have too many clusters to browse at a time, install the command-line
-binary via:
+如果一次要浏览的集群太多，请通过下面的命令来安装二进制命令`clusteradm`：
 
 ```shell
 curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
 ```
 
-Then run the following commands to see the details of the addon:
+然后通过运行下面的命令来获取多集群插件状态：
 
 ```shell
 $ clusteradm get addon
@@ -72,10 +63,9 @@ $ clusteradm get addon
             └── ...
 ```
 
-### Sample of ClusterGatewayConfiguration API
+### ClusterGatewayConfiguration API 配置示例
 
-You can read or edit the overall configuration of cluster-gateway deployments
-via the following command:
+你可以通过以下命令来查看或编辑集群网关部署的整体配置信息：
 
 ```shell
 $ kubectl get clustergatewayconfiguration -o yaml

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/overview.md
@@ -2,19 +2,18 @@
 title: 内置插件包
 ---
 
-There's an community addon registry (https://addons.kubevela.net) maintained by KubeVela team. It contains following addons:
-
-* [VelaUX](./velaux): The KubeVela User Experience (UX ) addon. It will launch a dashboard and an APIServer for better user experience.
-* [FluxCD](./fluxcd): Provides capability to deliver helm chart and drive GitOps.
-* [Addon Cloud Resources](./terraform): Provide a bunch of addons to provision cloud resources for different cloud providers.
-* [Machine Learning Addon](./ai): Machine learning addon is divided into model-training addon and model-serving addon.
-* [Traefik](./traefik): Traefik is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease.
-* [Rollout](./rollout): Provide a capability rollout the applicaton.
-* [Pyroscope](./pyroscope): Pyroscope is an open source platform, consisting of server and agent. It allows the user to collect, store, and query the profiling data in a CPU and disk efficient way.
-* [AI addon](./ai) Introduction modeling-training and modeling-serving addon.
-* [Vegeta](./vegeta) Vegeta is a versatile HTTP load testing tool built out of a need to drill HTTP services with a constant request rate. It can be used both as a command line utility and a library.
-* [OCM Cluster-Gateway Manager](./ocm-gateway-manager-addon) An operator component into the hub cluster that help the administrator to easily operate the configuration of cluster-gateway instances via "ClusterGatewayConfiguration"custom resource. *WARNING* this addon will restart the cluster-gateway instances upon the first-time installation.
-* [OCM Hub Control Plane](./ocm-hub-control-plane) Help you to initiate and install the [cluster manager](https://open-cluster-management.io/getting-started/core/cluster-manager/)(i.e. OCM's control plane) components into the hosting cluster where your KubeVela control plane is running.
-* [Vela prism](./vela-prism) Provide API Extensions to the core [KubeVela](https://github.com/kubevela/kubevela).
-* [Cert manager](./cert-manager) Add certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.
-* [KubeVela doc](./kubevela-io) Help you to read the KubeVela document in your cluster which can be air-gaped environment.
+以下内置插件都在由 KubeVela 团队维护的社区插件库（ https://addons.kubevela.net ）中：
+* [VelaUX](./velaux) KubeVela 用户体验 (UX) 插件。 它将启动仪表板和 APIServer 以获得更好的用户体验。
+* [FluxCD](./fluxcd) 提供交付 helm chart 和驱动 GitOps 的能力。
+* [Addon Cloud Resources](./terraform) 提供一堆插件用于处理不同云厂商的资源。
+* [Machine Learning Addon](./ai) 机器学习插件分为模型训练和建模插件。
+* [Traefik](./traefik) Traefik 是一个现代化的轻松部署的微服务 HTTP 反向代理服务器和负载均衡器。
+* [Rollout](./rollout) 提供应用回滚的能力。
+* [Pyroscope](./pyroscope) Pyroscope 是一个开源的平台，由服务端和代理组成。它提供给用户高效收集、存储以及查询 CPU 和磁盘状态的能力。
+* [AI addon](./ai) 介绍建模训练和建模服务插件。
+* [Vegeta](./vegeta) Vegeta 是一种多功能的 HTTP 负载测试工具，它是基于对具有恒定请求率的 HTTP 服务的需求而构建的。它既可以用作命令行实用程序，也可以用作库。
+* [OCM Cluster-Gateway Manager](./ocm-gateway-manager-addon)  管控集群中的 Operator 组件，帮助管理员通过自定义资源 `ClusterGatewayConfiguration` 来轻松操作集群网关实例的配置。 *警告*：此插件将在首次安装时重新启动集群网关实例。
+* [OCM Hub Control Plane](./ocm-hub-control-plane) 帮助您启动 [Cluster manager](https://open-cluster-management.io/getting-started/core/cluster-manager/)（即 OCM 的控制平面）组件并将其安装到运行 KubeVela 控制平面的托管集群中。
+* [Vela prism](./vela-prism) 为核心 [KubeVela](https://github.com/kubevela/kubevela)  提供 API 扩展。
+* [Cert manager](./cert-manager) 在 Kubernetes 集群中添加证书和证书颁发者作为资源类型，并简化获取、更新和使用这些证书的过程。
+* [KubeVela doc](./kubevela-io) 帮助你在集群中无缝查看 KubeVela 文档。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/pyroscope.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/pyroscope.md
@@ -1,0 +1,239 @@
+---
+title: Pyroscope
+---
+
+Pyroscope 是一个开源平台，由服务器和代理组成。 它允许用户以 CPU 和磁盘高效的方式收集、存储和查询分析数据。这个插件基于 [Pyroscope](https://github.com/pyroscope-io/pyroscope) 构建。
+
+##  安装插件
+
+```shell
+vela addon enable pyroscope
+```
+
+在成功启用 pyroscope 之后，你可以执行下面的命令来暴露`4040`端口以提供控制台界面访问。
+
+```shell
+vela port-forward addon-pyroscope -n vela-system
+```
+
+## 如何使用 pyroscope trait
+
+使用一个 webservice 组件来开始，将下面的声明保存到 pyroscope-demo.yaml，并运行 vela up -f app-demo.yaml 来启动。
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: pyroscope-app
+  namespace: fourier
+spec:
+  components:
+    - name: pyroscope-comp-01
+      type: webservice
+      properties:
+        image: nginx:latest
+        ports:
+          - expose: true
+            port: 80
+            protocol: TCP
+        imagePullPolicy: IfNotPresent
+      traits:
+        - type: pyroscope
+          properties:
+            server: "http://pyroscope-server:9084"
+            logger: "pyroscope.StandardLogger"
+            appName: "pyroscope-test"
+        - type: scaler
+          properties:
+            replicas: 1
+```
+`appName`参数是一个可选字段，默认值是这个组件的名字。
+
+## 如何使用 pyroscope 客户端
+### 在 Golang 应用中使用 Pyroscope
+
+- 为了在 Go 应用中启用分析，你需要在你的应用中导入 Pyroscope 模块。
+```shell
+# make sure you also upgrade pyroscope server to version 0.3.1 or higher
+go get github.com/pyroscope-io/client/pyroscope
+```
+- 然后，在你的应用中添加如下代码：
+```go
+package main
+
+import "github.com/pyroscope-io/client/pyroscope"
+
+func main() {
+  pyroscope.Start(pyroscope.Config{
+    ApplicationName: "simple.golang.app",
+    // 将这个地址替换为你的 pyroscope 服务端地址
+    ServerAddress:   "http://pyroscope-server:4040",
+    // 你可以通过设置值为 nil 来禁用日志
+    Logger:          pyroscope.StandardLogger,
+
+    // 如果 pyroscope 服务端启用了认证，需要指定 API 密钥：
+    // AuthToken: os.Getenv("PYROSCOPE_AUTH_TOKEN"),
+
+    // 默认启用所有的分析器，但是你也可以指定你想要启用的分析器：
+    ProfileTypes: []pyroscope.ProfileType{
+      pyroscope.ProfileCPU,
+      pyroscope.ProfileAllocObjects,
+      pyroscope.ProfileAllocSpace,
+      pyroscope.ProfileInuseObjects,
+      pyroscope.ProfileInuseSpace,
+    },
+  })
+
+  // your code goes here
+}
+```
+- 查看 [示例代码](https://github.com/pyroscope-io/pyroscope/tree/main/examples/golang-push) 目录来获取更多使用示例。
+
+###  在 Java 应用中使用 Pyroscope
+
+- Java 集成是通过一个名叫 pyroscope.jar 的 jar 包分发的。它包含了原生的 async-profile 库。
+- 要开始分析一个 Java 应用，通过使用 pyroscope.jar 的 javaagent 来启动你的程序：
+```shell
+export PYROSCOPE_APPLICATION_NAME=my.java.app
+export PYROSCOPE_SERVER_ADDRESS=http://pyroscope-server:4040
+
+# 如果 pyroscope 服务端启用了认证，需要指定 API 密钥：
+# export PYROSCOPE_AUTH_TOKEN={YOUR_API_KEY}
+
+java -javaagent:pyroscope.jar -jar app.jar
+```
+- 查看 [示例代码](https://github.com/pyroscope-io/pyroscope/tree/main/examples/java) 目录来获取更多使用示例。
+
+### 在.NET 应用中使用 Pyroscope
+
+- 要开始分析容器里的 .NET 应用，你需要用 pyroscope exec 来包装你的应用程序作为镜像的 entrypoint。你需要在你的 Dockerfile 中使用 COPY --from 将 pyroscope 可执行二进制拷贝到你的容器里。
+下面的 Dockerfile 演示了如何构建这个镜像：
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+WORKDIR /dotnet
+
+COPY --from=pyroscope/pyroscope:latest /usr/bin/pyroscope /usr/bin/pyroscope
+ADD my-app .
+RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' ')
+
+# 你可以像设置 pyroscope 服务地址一样设置其他的配置选项。
+ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope-server:4040
+ENV PYROSCOPE_APPLICATION_NAME=my.dotnet.app
+ENV PYROSCOPE_LOG_LEVEL=debug
+
+CMD ["pyroscope", "exec", "dotnet", "/dotnet/my-app.dll"]
+```
+- 如果你正在使用 Docker Compose，那么你可以使用下面的配置同时运行 pyroscope 服务端和客户端。
+```yaml
+---
+version: "3.9"
+services:
+  pyroscope-server:
+    image: "pyroscope/pyroscope:latest"
+    ports:
+      - "4040:4040"
+    command:
+      - "server"
+  app:
+    image: "my-app:latest"
+    environment:
+      PYROSCOPE_APPLICATION_NAME: my.dotnet.app
+      PYROSCOPE_SERVER_ADDRESS: http://pyroscope-server:4040
+      PYROSCOPE_LOG_LEVEL: debug
+      ASPNETCORE_URLS: http://*:5000
+    ports:
+      - "5000:5000"
+    cap_add:
+      - SYS_PTRACE
+```
+- 查看 [示例代码](https://github.com/pyroscope-io/pyroscope/tree/main/examples/dotnet) 目录来获取更多使用示例。
+
+### 在 Python 应用中使用 Pyroscope
+
+- 首先，安装 pyroscope-io 的 pip 包：
+```shell
+pip install pyroscope-io
+```
+- 然后在你的应用中添加下面的代码。这些代码将会初始化 pyroscope 分析器并且启动分析：
+```shell
+import pyroscope
+
+pyroscope.configure(
+  app_name       = "my.python.app", # 将这里替换为你的应用名称
+  server_address = "http://my-pyroscope-server:4040", # 将这个地址替换为你的 pyroscope 服务端地址
+# auth_token     = "{YOUR_API_KEY}", # 如果 pyroscope 服务端启用了认证，需要指定 API 密钥
+)
+```
+-  查看 pyroscope 仓库中的 [python 项目中的 pyroscope 示例](https://github.com/pyroscope-io/pyroscope/tree/main/examples/python) 来获取更多使用示例。
+
+### 在 PHP 应用中使用 Pyroscope
+
+- 要开始分析容器里的 PHP 应用，你需要用 pyroscope exec 来包装你的应用程序作为镜像的 entrypoint。你需要在你的 Dockerfile 中使用 COPY --from 将 pyroscope 可执行二进制拷贝到你的容器里。
+下面的 Dockerfile 演示了如何构建这个镜像：
+
+```dockerfile
+FROM php:7.3.27
+
+WORKDIR /var/www/html
+
+# 这条命令从 pyroscope 镜像中拷贝 pyroscope 二进制文件到你的镜像
+COPY --from=pyroscope/pyroscope:latest /usr/bin/pyroscope /usr/bin/pyroscope
+COPY main.php ./main.php
+
+# 通常你可以像设置 app name 一样来设置 pyroscope 服务端地址，请确保更新下面的配置：
+ENV PYROSCOPE_APPLICATION_NAME=my.php.app
+ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040/
+
+# 通过下面的命令来启动一个带 pyroscope 分析器的应用程序，请务必修改 "php" 和 "main.php" 为实际的命令。
+CMD ["pyroscope", "exec", "php", "main.php"]
+```
+- 如果你正在使用 Docker Compose，那么你可以使用下面的配置同时运行 pyroscope 服务端和客户端。
+```yaml
+---
+services:
+  pyroscope-server:
+    image: "pyroscope/pyroscope:latest"
+    ports:
+      - "4040:4040"
+    command:
+      - "server"
+  app:
+    image: "my-app:latest"
+    env:
+      PYROSCOPE_SERVER_ADDRESS: http://pyroscope-server:4040
+      PYROSCOPE_APPLICATION_NAME: my.php.app
+    cap_add:
+      - SYS_PTRACE
+```
+- 查看 [示例代码](https://github.com/pyroscope-io/pyroscope/tree/main/examples/php) 目录来获取更多使用示例。
+
+### 在 NodeJS 应用中使用 Pyroscope
+
+- 要在一个 NodeJS 项目中启用 pyroscope 分析器，你需要使用 npm 来导入模块：
+```shell
+npm install @pyroscope/nodejs
+
+# 或者
+yarn add @pyroscope/nodejs
+```
+- 然后，在你的应用中添加下面的代码：
+```js
+const Pyroscope = require('@pyroscope/nodejs');
+
+Pyroscope.init({
+  serverAddress: 'http://pyroscope:4040',
+  appName: 'myNodeService'
+});
+
+Pyroscope.start()
+```
+- 查看 [示例代码](https://github.com/pyroscope-io/pyroscope/tree/main/examples/nodejs) 目录来获取更多使用示例。
+
+
+## 卸载插件
+
+```shell
+vela addon disable pyroscope
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/vegeta.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/vegeta.md
@@ -2,25 +2,25 @@
 title: vegeta
 ---
 
-## Install
+## 安装插件
 
 ```shell
 $ vela addon enable vegeta
 ```
 
-## Uninstall
+## 卸载插件
 
 ```shell
 $ vela addon disable vegeta
 ```
 
-## Supported workload type
+## 支持的工作负载类型
 
-Vegeta Trait supports following component types: webservice, worker and cloneset.
+Vegeta Trait 支持下面的几种工作负载webservice，worker 和 cloneset。
 
-## How to start
+## 开始使用
 
-Use a component typed webservice to start, keep the following to show-vegeta.yaml, then vela up -f show-vegeta.yaml
+使用一个 webservice 组件来开始，将下面的声明保存到 show-vegeta.yaml，并运行 vela up -f show-vegeta.yaml 来启动。
 
 ```shell
 apiVersion: core.oam.dev/v1beta1
@@ -48,7 +48,7 @@ spec:
             backofflimit: 10
 ```
 
-Check the app status and trait status
+检查 app 和 trait 的状态：
 
 ```shell
 vela ls app -n vegeta
@@ -93,11 +93,12 @@ vela logs new-vegeta --name new-vegeta -n vegeta
 Choose the Job to show testing data logs
 ```
 
-- If you want a more nice demo, use the two tools: jaggr and jplot to show the data
+- 如果你想获取一个更友好的输出，使用下面这两个工具： jaggr 和 jplot 来查看数据。
+
 ```shell
 kubectl logs new-vegeta--1-qrh67  -n vegeta -f | jaggr @count=rps hist\[100,200,300,400,500\]:code p25,p50,p95:latency sum:bytes_in sum:bytes_out | jplot rps+code.hist.100+code.hist.200+code.hist.300+code.hist.400+code.hist.500 latency.p95+latency.p50+latency.p25 bytes_in.sum+bytes_out.sum
 ```
 
-- How to install jplot and jagrr
+- 如何安装 jplot 和 jagrr
     - https://github.com/rs/jplot
     - https://github.com/rs/jaggr

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/velaux.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/velaux.md
@@ -2,54 +2,53 @@
 title: VelaUX 控制台
 ---
 
-## Install
+## 安装插件
 
 ```shell script
 vela addon enable velaux --version=v1.4.3
 ```
 
-expected output:
+期望得到的输出如下：
 ```
 Addon: velaux enabled Successfully.
 ```
 
-VelaUX needs authentication. The default username is `admin` and the password is **`VelaUX12345`**. Please must set and remember the new password after the first login.
+VelaUX 需要认证访问。默认的用户名是`admin`，默认密码是 **VelaUX12345**。请务必在第一次登录之后重新设置和保管好你的新密码。
 
-By default, VelaUX didn't have any exposed port.
+默认情况下， VelaUX 没有暴露任何端口。
 
-## Visit VelaUX by port-forward
+## 通过端口转发来访问 VelaUX
 
-Port forward will work as a proxy to allow visiting VelaUX dashboard by local port.
+端口转发会以代理的方式允许你通过本地端口来访问 VelaUX 控制台。
 
 ```
 vela port-forward addon-velaux -n vela-system
 ```
 
-Choose `> Cluster: local | Namespace: vela-system | Component: velaux | Kind: Service` for visit.
+选择 `> Cluster: local | Namespace: vela-system | Component: velaux | Kind: Service` 来启用端口转发。
 
-## Setup with Specified Service Type
+## 配置特定服务访问方式
 
-There are three service types for VelaUX addon which aligned with Kubernetes service, they're `ClusterIP`, `NodePort` and `LoadBalancer`.
-By default the service type is ClusterIP for security.
+VelaUX 控制台插件支持三种和 Kubernetes 服务一样的服务访问方式，它们是：`ClusterIP`，`NodePort`以及`LoadBalancer`。
 
-If you want to expose your VelaUX dashboard for convenience, you can specify the service type.
+为了安全起见，默认的服务访问方式为 ClusterIP。
 
-- `LoadBalancer` type requires your cluster has cloud LoadBalancer available.
+如果你想要改变 VelaUX 控制台的访问方式，你需要通过下面的方法来改变：
+
+- `LoadBalancer`方式需要你的集群有可用的 LoadBalancer。
     ```shell script
     vela addon enable velaux serviceType=LoadBalancer
     ```
-- `NodePort` type requires you can access the Kubernetes Node IP/Port.
+- `NodePort`方式需要你能够访问 Kubernetes 节点 IP 和 端口。
     ```shell script
     vela addon enable velaux serviceType=NodePort
     ```
-
-After the service type specified to `LoadBalancer` or `NodePort`, you can obtain the access address through `vela status`:
-
+一旦服务访问方式指定为`LoadBalancer`或者`NodePort`，你可以通过执行`vela status`来获取访问地址：
 ```
 vela status addon-velaux -n vela-system --endpoint
 ```
 
-The expected output:
+期望得到的输出如下：
 ```
 +----------------------------+----------------------+
 |  REF(KIND/NAMESPACE/NAME)  |       ENDPOINT       |
@@ -58,15 +57,15 @@ The expected output:
 +----------------------------+----------------------+
 ```
 
-## Setup with Ingress domain
+## 配置 Ingress 域名访问
 
-If you have ingress and domain available in your cluster, you can also deploy VelaUX by specify a domain like below:
+如果你集群中拥有可用的 ingress 和域名，那么你可以按照下面的方式给你的 VelaUX 在部署过程中指定一个域名。
 
 ```bash
 vela addon enable velaux domain=example.doamin.com
 ```
 
-The expected output:
+期望得到的输出如下：
 ```
 I0112 15:23:40.428364   34884 apply.go:106] "patching object" name="addon-velaux" resource="core.oam.dev/v1beta1, Kind=Application"
 I0112 15:23:40.676894   34884 apply.go:106] "patching object" name="addon-secret-velaux" resource="/v1, Kind=Secret"
@@ -79,31 +78,31 @@ Please access the velaux from the following endpoints:
 +----------------------------+---------------------------+
 ```
 
-If you enabled the traefik addon, you can set the `gatewayDriver` parameter to use the Gateway API.
+如果你已经启用了 traefik 插件，那么你可以指定`gatewayDriver`参数来启用网关 API。
 
 ```shell script
 vela addon enable velaux domain=example.doamin.com gatewayDriver=traefik
 ```
 
-## Setup with MongoDB database
+## 配置 MongoDB
 
-VelaUX supports the Kubernetes and MongoDB as the database. the default is Kubernetes. We strongly advise using the MongoDB database to power your production environment.
+VelaUX 支持 Kubernetes 和 MongoDB 作为其数据库。默认数据库为 Kubernetes。我们强烈建议你通过使用 MongoDB 来增强你的生产环境使用体验。
 
 ```shell script
 vela addon enable velaux dbType=mongodb dbURL=mongodb://<MONGODB_USER>:<MONGODB_PASSWORD>@<MONGODB_URL>
 ```
 
-## Specify the addon image
+## 指定插件镜像仓库
 
-By default the image repo is docker hub, you can specify the image repo by the `repo` parameter: 
+默认情况下，VelaUX 仓库使用的是 docker hub，你可以通过`repo`参数来改变插件镜像的仓库：
 
 ```shell script
 vela addon enable velaux repo=acr.kubevela.net
 ```
 
-You can try to specify the `acr.kubevela.net` image registry as an alternative, It's maintained by KubeVela team, and we will upload/sync the built-in addon image for convenience.
+你可以尝试指定`acr.kubevela.net` 镜像注册表作为 docker hub 的替换，这个镜像仓库由 KubeVela 团队维护，并且他们会定期上传/同步内建组件到这个仓库。
 
-This feature can also help you to build your private installation, just upload all images to your private image registry.
+这个特性也同样可以帮助你使用你的私有仓库来完成安装，你仅仅需要将所有镜像都上传到你的私有镜像仓库即可。
 
 ## VelaUX 概念
 


### PR DESCRIPTION
i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/kubevela-io.md #7
原文：Use this addon can help you to read the document in your cluster which can be air-gaped environment.
译文：使用此插件可以帮助您在集群中无缝查阅文档。

文件位置：i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/ocm-gateway-manager-addon.md #5
原文：__TL;DR__: "OCM Cluster-Gateway Manager" addon installs an operator component
into the hub cluster that help the administrator to easily operate the
configuration of cluster-gateway instances via "ClusterGatewayConfiguration"
custom resource. *WARNING* this addon will restart the cluster-gateway
instances upon the first-time installation.
译文：OCM Cluster-Gateway Manager 插件在管理集群中安装了一个 operator 组件，帮助管理员通过自定义资源ClusterGatewayConfiguration  轻松操作集群网关实例的配置。 *警告*：此插件将在首次安装时重新启动集群网关实例。

i18n/zh/docusaurus-plugin-content-docs/version-v1.4/reference/addons/overview.md #12
原文：Pyroscope is an open source platform, consisting of server and agent. It allows the user to collect, store, and query the profiling data in a CPU and disk efficient way.
译文：Pyroscope 是一个开源的平台，由服务端和代理组成。它提供给用户收集、存储以及查询 CPU 和磁盘状态的能力。