### PR TITLE
Chore: update node version and use cache

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,10 +37,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
+          cache: "yarn"
       - name: Test Build
         run: |
           yarn install --frozen-lockfile --production=false
           yarn build
+
   gh-release:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -49,6 +51,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
+          cache: "yarn"
       - name: Build Static Files
         env:
           USE_SSH: true
@@ -57,7 +60,6 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
-          yarn add nodejieba
           yarn install --frozen-lockfile --production=false
           yarn build
       - name: Install ossutil

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "16.x"
+          cache: "yarn"
       - name: Build Static Files
         env:
           USE_SSH: true
@@ -24,15 +25,8 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
-          yarn add nodejieba
-          if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
-          elif [ -e package-lock.json ]; then
-          npm ci
-          else
-          npm install
-          fi
-          npm run build
+          yarn install --frozen-lockfile --production=false
+          yarn build
       - name: Get the version
         id: get_version
         run: |


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

This workflow is failing due to out dated node versions:
![image](https://user-images.githubusercontent.com/55270174/175826153-52c9f57b-197d-4b91-8b18-7a509a5a9430.png)

What this pr does:

- Updated node to `16.x`
- Included cache to speed up workflows
- Removes `yarn add nodejieba`. It seems this command is not required, since `nodejieba` is already included in `package.json`. No need to install it again during CI.