### PR TITLE
docs: add vela and velad installation instructions for asdf-vm

### DIFF
--- a/docs/installation/kubernetes.mdx
+++ b/docs/installation/kubernetes.mdx
@@ -28,6 +28,7 @@ KubeVela CLI provides an easy to engage and manage your application delivery in 
       {label: 'Script', value: 'script'},
       {label: 'Homebrew', value: 'homebrew'},
       {label: 'Download directly from releases', value: 'download'},
+      {label: 'Asdf-vm', value: 'asdf-vm'},
       {label: 'Docker', value: 'docker'},
     ]}>
 <TabItem value="script">
@@ -51,7 +52,7 @@ powershell -Command "iwr -useb https://kubevela.net/script/install.ps1 | iex"
 </TabItem>
 <TabItem value="homebrew">
 
-**macOS/Linux**
+**MacOS/Linux**
 
 Update your brew first. Please note that the brew method only supports the installation of the official release version.
 
@@ -81,6 +82,29 @@ sudo mv ./vela /usr/local/bin/vela
 - MacOS imposes stricter restrictions on the software that can run in the system. You can temporarily solve this problem by opening `System Preference ->Security & Privacy -> General` and clicking on `Allow Anyway`.
 :::
 </TabItem>
+
+<TabItem value="asdf-vm">
+
+** MacOS/Linux **
+
+If you are using the [asdf version manager](https://asdf-vm.com/), you can install `vela` with:
+
+```shell script
+# Add the vela plugin for asdf
+asdf plugin add vela
+
+# List all installable versions
+asdf list-all vela
+
+# Install the desired version (could be "latest")
+asdf install vela <version>
+
+# set it as the global version, unless a project declares it otherwise locally
+asdf global vela <version>
+```
+
+</TabItem>
+
 <TabItem value="docker">
 
 If you have docker environment, you can easily run CLI with the vela CLI docker image called `oamdev/vela-cli`:

--- a/docs/installation/standalone.mdx
+++ b/docs/installation/standalone.mdx
@@ -48,7 +48,7 @@ VelaD support installing KubeVela on machines based on these OS: Linux, macOS, W
 It will download and place the binary in your system `PATH`,
 
 <Tabs className="unique-tabs" groupId="os">
-<TabItem label="Linux/macOS" value="unix">
+<TabItem label="Linux/MacOS Script" value="script">
 
 You may be required for root privilege during the installation process if not using root.
 If you don't need the automation with root access, you can download from the [release page](https://github.com/kubevela/velad/releases) and uncompress manually.
@@ -59,6 +59,24 @@ curl -fsSl https://static.kubevela.net/script/install-velad.sh | bash
 
 Check `velad` installed in `/usr/local/bin/`
 
+</TabItem>
+<TabItem label="Linux/MacOS with asdf-vm" value="asdf-vm">
+
+If you are using the [asdf version manager](https://asdf-vm.com/), you can install `velad` with:
+
+```shell script
+# Add the velad plugin for asdf
+asdf plugin add velad
+
+# List all installable versions
+asdf list-all velad
+
+# Install the desired version (could be "latest")
+asdf install velad <version>
+
+# set it as the global version, unless a project declares it otherwise locally
+asdf global velad <version>
+```
 </TabItem>
 <TabItem label="Windows" value="win">
 

--- a/versioned_docs/version-v1.6/installation/kubernetes.mdx
+++ b/versioned_docs/version-v1.6/installation/kubernetes.mdx
@@ -28,6 +28,7 @@ KubeVela CLI provides an easy to engage and manage your application delivery in 
       {label: 'Script', value: 'script'},
       {label: 'Homebrew', value: 'homebrew'},
       {label: 'Download directly from releases', value: 'download'},
+      {label: 'Asdf-vm', value: 'asdf-vm'},
       {label: 'Docker', value: 'docker'},
     ]}>
 <TabItem value="script">
@@ -51,7 +52,7 @@ powershell -Command "iwr -useb https://kubevela.net/script/install.ps1 | iex"
 </TabItem>
 <TabItem value="homebrew">
 
-**macOS/Linux**
+**MacOS/Linux**
 
 Update your brew first. Please note that the brew method only supports the installation of the official release version.
 
@@ -81,6 +82,29 @@ sudo mv ./vela /usr/local/bin/vela
 - MacOS imposes stricter restrictions on the software that can run in the system. You can temporarily solve this problem by opening `System Preference ->Security & Privacy -> General` and clicking on `Allow Anyway`.
 :::
 </TabItem>
+
+<TabItem value="asdf-vm">
+
+** MacOS/Linux **
+
+If you are using the [asdf version manager](https://asdf-vm.com/), you can install `vela` with:
+
+```shell script
+# Add the vela plugin for asdf
+asdf plugin add vela
+
+# List all installable versions
+asdf list-all vela
+
+# Install the desired version (could be "latest")
+asdf install vela <version>
+
+# set it as the global version, unless a project declares it otherwise locally
+asdf global vela <version>
+```
+
+</TabItem>
+
 <TabItem value="docker">
 
 If you have docker environment, you can easily run CLI with the vela CLI docker image called `oamdev/vela-cli`:

--- a/versioned_docs/version-v1.6/installation/standalone.mdx
+++ b/versioned_docs/version-v1.6/installation/standalone.mdx
@@ -48,7 +48,7 @@ VelaD support installing KubeVela on machines based on these OS: Linux, macOS, W
 It will download and place the binary in your system `PATH`,
 
 <Tabs className="unique-tabs" groupId="os">
-<TabItem label="Linux/macOS" value="unix">
+<TabItem label="Linux/MacOS Script" value="script">
 
 You may be required for root privilege during the installation process if not using root.
 If you don't need the automation with root access, you can download from the [release page](https://github.com/kubevela/velad/releases) and uncompress manually.
@@ -59,6 +59,24 @@ curl -fsSl https://static.kubevela.net/script/install-velad.sh | bash
 
 Check `velad` installed in `/usr/local/bin/`
 
+</TabItem>
+<TabItem label="Linux/MacOS with asdf-vm" value="asdf-vm">
+
+If you are using the [asdf version manager](https://asdf-vm.com/), you can install `velad` with:
+
+```shell script
+# Add the velad plugin for asdf
+asdf plugin add velad
+
+# List all installable versions
+asdf list-all velad
+
+# Install the desired version (could be "latest")
+asdf install velad <version>
+
+# set it as the global version, unless a project declares it otherwise locally
+asdf global velad <version>
+```
 </TabItem>
 <TabItem label="Windows" value="win">
 


### PR DESCRIPTION
### Description of your changes

Hi,

This PR adds vela and velad installation instructions for the [asdf-vm runtime manager](https://asdf-vm.com/), as proposed [here](https://github.com/kubevela/kubevela/discussions/5114).
[This PR](https://github.com/asdf-vm/asdf-plugins/pull/709) and [this PR](https://github.com/asdf-vm/asdf-plugins/pull/710) are merged in the [asdf-plugins](https://github.com/asdf-vm/asdf-plugins) repository, so it's all good on the asdf side ;)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.