### PR TITLE
Docs: update outdated instructions for docgen

### DIFF
--- a/docs/contributor/cli-ref-doc.md
+++ b/docs/contributor/cli-ref-doc.md
@@ -153,8 +153,8 @@ By default, the definition don't contain any examples, maintainers can specify e
 The docs folder will be embedded into CLI binary, you must write into the following hierarchy:
 
 ```console
-$ tree references/plugins/def-doc
-references/plugins/def-doc
+$ tree references/docgen/def-doc
+references/docgen/def-doc
 ├── component
 │   ├── webservice.eg.md
 │   ├── webservice.param.md

--- a/docs/contributor/cli-ref-doc.md
+++ b/docs/contributor/cli-ref-doc.md
@@ -54,11 +54,12 @@ Most of the steps are done by script automatically. You need to follow this guid
 By default, the following steps will update for all definition reference at a time.
 Just follow these steps.
 
-1. step up these two projects in the same folder.
+1. step up these three projects in the same folder.
 
 ```shell
 $ tree -L 1
 .
+├── catalog
 ├── kubevela
 └── kubevela.io
 ```
@@ -81,7 +82,7 @@ git status
 
 That's finished for the general update.
 
-### Update for Specific 
+### Update for Specific
 
 You can specify some args for more flexible usage.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor/cli-ref-doc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor/cli-ref-doc.md
@@ -153,8 +153,8 @@ By default, the definition don't contain any examples, maintainers can specify e
 The docs folder will be embedded into CLI binary, you must write into the following hierarchy:
 
 ```console
-$ tree references/plugins/def-doc
-references/plugins/def-doc
+$ tree references/docgen/def-doc
+references/docgen/def-doc
 ├── component
 │   ├── webservice.eg.md
 │   ├── webservice.param.md

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor/cli-ref-doc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor/cli-ref-doc.md
@@ -54,11 +54,12 @@ Most of the steps are done by script automatically. You need to follow this guid
 By default, the following steps will update for all definition reference at a time.
 Just follow these steps.
 
-1. step up these two projects in the same folder.
+1. step up these three projects in the same folder.
 
 ```shell
 $ tree -L 1
 .
+├── catalog
 ├── kubevela
 └── kubevela.io
 ```
@@ -81,7 +82,7 @@ git status
 
 That's finished for the general update.
 
-### Update for Specific 
+### Update for Specific
 
 You can specify some args for more flexible usage.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/contributor/cli-ref-doc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/contributor/cli-ref-doc.md
@@ -153,8 +153,8 @@ By default, the definition don't contain any examples, maintainers can specify e
 The docs folder will be embedded into CLI binary, you must write into the following hierarchy:
 
 ```console
-$ tree references/plugins/def-doc
-references/plugins/def-doc
+$ tree references/docgen/def-doc
+references/docgen/def-doc
 ├── component
 │   ├── webservice.eg.md
 │   ├── webservice.param.md

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/contributor/cli-ref-doc.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/contributor/cli-ref-doc.md
@@ -54,11 +54,12 @@ Most of the steps are done by script automatically. You need to follow this guid
 By default, the following steps will update for all definition reference at a time.
 Just follow these steps.
 
-1. step up these two projects in the same folder.
+1. step up these three projects in the same folder.
 
 ```shell
 $ tree -L 1
 .
+├── catalog
 ├── kubevela
 └── kubevela.io
 ```
@@ -81,7 +82,7 @@ git status
 
 That's finished for the general update.
 
-### Update for Specific 
+### Update for Specific
 
 You can specify some args for more flexible usage.
 

--- a/versioned_docs/version-v1.7/contributor/cli-ref-doc.md
+++ b/versioned_docs/version-v1.7/contributor/cli-ref-doc.md
@@ -153,8 +153,8 @@ By default, the definition don't contain any examples, maintainers can specify e
 The docs folder will be embedded into CLI binary, you must write into the following hierarchy:
 
 ```console
-$ tree references/plugins/def-doc
-references/plugins/def-doc
+$ tree references/docgen/def-doc
+references/docgen/def-doc
 ├── component
 │   ├── webservice.eg.md
 │   ├── webservice.param.md

--- a/versioned_docs/version-v1.7/contributor/cli-ref-doc.md
+++ b/versioned_docs/version-v1.7/contributor/cli-ref-doc.md
@@ -54,11 +54,12 @@ Most of the steps are done by script automatically. You need to follow this guid
 By default, the following steps will update for all definition reference at a time.
 Just follow these steps.
 
-1. step up these two projects in the same folder.
+1. step up these three projects in the same folder.
 
 ```shell
 $ tree -L 1
 .
+├── catalog
 ├── kubevela
 └── kubevela.io
 ```
@@ -81,7 +82,7 @@ git status
 
 That's finished for the general update.
 
-### Update for Specific 
+### Update for Specific
 
 You can specify some args for more flexible usage.
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

#### patch 1

In [kubevela#5351](https://github.com/kubevela/kubevela/pull/5351), `"../catalog/addons/vela-workflow/definitions"` was added into `WorkflowDefDirs`. So, to run the docgen, we also need to step up catalog repo folder in the same folder.

Before we have the catalog repo folder in the path same as kubevela and kubevela.io:
<img width="1156" alt="截屏2023-02-20 23 55 07" src="https://user-images.githubusercontent.com/57584831/220249471-0dc3fe40-1016-4ed9-b574-b6d9343af21a.png">

After:
<img width="1185" alt="截屏2023-02-20 23 55 34" src="https://user-images.githubusercontent.com/57584831/220249487-c6b7c441-b87f-4fc2-85ab-1b43cc27670e.png">

#### patch 2

In kubevela repo, path `references/plugins/def-doc` has been changed to `references/docgen/def-doc`. We should also keep the doc contents updated.

