### PR TITLE
Fix: clean-jobs workflow step doc typo

### DIFF
--- a/docs/end-user/workflow/built-in-workflow-defs.md
+++ b/docs/end-user/workflow/built-in-workflow-defs.md
@@ -759,7 +759,7 @@ spec:
     - name: clean-cli-jobs
       type: clean-jobs
       properties:
-        labelSelector:
+        labelselector:
           "my-label": my-value
 ```
 

--- a/versioned_docs/version-v1.7/end-user/workflow/built-in-workflow-defs.md
+++ b/versioned_docs/version-v1.7/end-user/workflow/built-in-workflow-defs.md
@@ -759,7 +759,7 @@ spec:
     - name: clean-cli-jobs
       type: clean-jobs
       properties:
-        labelSelector:
+        labelselector:
           "my-label": my-value
 ```
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

In official docs, the clean-jobs params key is `labelSelector`
<img width="571" alt="image" src="https://user-images.githubusercontent.com/93654253/231691520-ae6ac4be-db1f-4520-8799-0b2dbf1428c9.png">

But in clean-jobs.cue, the params declare is `labelselector`
https://github.com/kubevela/kubevela/blob/fea7ae59354b37cb29a5ccd177053d94c0f61264/vela-templates/definitions/internal/workflowstep/clean-jobs.cue#L16-L19

@wonderflow PTAL, this file has no reviewers

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->