### PR TITLE
fix the wrong content

### DIFF
--- a/docs/end-user/traits/sidecar.md
+++ b/docs/end-user/traits/sidecar.md
@@ -65,7 +65,7 @@ vela-app-with-sidecar	log-gen-worker	worker     	sidecar           	running	heal
 And check the logging output of sidecar. 
 
 ```shell
-vela logs vela-app-with-sidecar -c count-log
+vela logs vela-app-with-sidecar --container count-log
 ```
 
 <details>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/end-user/traits/sidecar.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/end-user/traits/sidecar.md
@@ -62,13 +62,29 @@ APP                 	COMPONENT     	TYPE       	TRAITS 	PHASE  	HEALTHY	STATUS	C
 vela-app-with-sidecar	log-gen-worker	worker     	sidecar           	running	healthy	      	2021-08-29 22:07:07 +0800 CST
 ```
 
-
 成功后，查看 Sidecar 所输出的日志
 
 
-```
-vela logs vela-app-with-sidecar -c count-log
+```shell
+vela logs vela-app-with-sidecar --container count-log
 ```
 
 从输出的日志可以看到读取日志的 sidecar 已经生效。
 
+<details>
+<summary>expected output</summary>
+
+```console
+0: Fri Apr 16 11:08:45 UTC 2021
+1: Fri Apr 16 11:08:46 UTC 2021
+2: Fri Apr 16 11:08:47 UTC 2021
+3: Fri Apr 16 11:08:48 UTC 2021
+4: Fri Apr 16 11:08:49 UTC 2021
+5: Fri Apr 16 11:08:50 UTC 2021
+6: Fri Apr 16 11:08:51 UTC 2021
+7: Fri Apr 16 11:08:52 UTC 2021
+8: Fri Apr 16 11:08:53 UTC 2021
+9: Fri Apr 16 11:08:54 UTC 2021 
+```
+
+</details>

--- a/i18n/zh/docusaurus-plugin-content-docs/current/reference/addons/nginx-ingress-controller.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/reference/addons/nginx-ingress-controller.md
@@ -7,7 +7,7 @@ title: Nginx Ingress Controller
 ##  安装
 
 ```shell
-vela addon enable ingress-controller
+vela addon enable ingress-nginx
 ```
 
 ## 指定 Service Type
@@ -16,12 +16,12 @@ vela addon enable ingress-controller
 
 - `LoadBalancer` 需要你的集群运行在某个公有云上，并有一种支持的 cloud LoadBalancer。
     ```shell script
-    vela addon enable ingress-controller serviceType=LoadBalancer
+    vela addon enable ingress-nginx serviceType=LoadBalancer
     ```   
   
 - `NodePort` 类型需要你能够访问集群节点的 IP和端口
     ```shell script
-    vela addon enable ingress-controller serviceType=NodePort
+    vela addon enable ingress-nginx serviceType=NodePort
     ```
   
 ## 获取网关地址
@@ -29,19 +29,19 @@ vela addon enable ingress-controller
 如果指定了服务类型是 `NodePort` 和 `LoadBalancer`，你可以通过下面的命令，获取到网关的地址：
 
 ```shell
-vela status addon-ingress-controller -n vela-system --endpoint
+vela status addon-ingress-nginx -n vela-system --endpoint
 ```
 
 如果是 `ClusterIP` 类型，又可以通过 `vela port-forward` 命令将网关的端口映射到本地：
 
 ```shell
-vela port-forward -n vela-system addon-ingress-controller 9080:80
+vela port-forward -n vela-system addon-ingress-nginx 9080:80
 ```
 
 ## 卸载
 
 ```shell
-vela addon disable ingress-controller
+vela addon disable ingress-nginx
 ```
 
 ## 例子
@@ -76,6 +76,3 @@ EOF
 $ curl -H "Host: canary-demo.com" <ingress-controller-endpoint>/version
 Demo: V1
 ```
-
-
-


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":



-->
Fixes #1229 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
The `-c` flag is the `-component` shorthand, not the `-container`.

```
vela logs -h
Tail logs for vela application.

Usage:
  vela logs APP_NAME [flags]

Flags:
      --cluster string     filter the pod by the cluster name
  -c, --component string   filter the pod by the component name
      --container string   specify the container name
  -e, --env string         specify environment name for application
  -h, --help               help for logs
  -n, --namespace string   specify the Kubernetes namespace to use
  -o, --output string      output format for logs, support: [default, raw, json] (default "default")
  -p, --pod string         specify the pod name

Global Flags:
  -y, --yes   Assume yes for all user prompts
```