### PR TITLE
Fix: modify the registry usage examples for gitlab and github type

### DIFF
--- a/docs/cli/vela_addon_registry_add.md
+++ b/docs/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/docs/cli/vela_addon_registry_add.md
+++ b/docs/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/i18n/zh/docusaurus-plugin-content-docs/current/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.6/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.7/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/cli/vela_addon_registry_add.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.8/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/versioned_docs/version-v1.6/cli/vela_addon_registry_add.md
+++ b/versioned_docs/version-v1.6/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/versioned_docs/version-v1.6/cli/vela_addon_registry_add.md
+++ b/versioned_docs/version-v1.6/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/versioned_docs/version-v1.7/cli/vela_addon_registry_add.md
+++ b/versioned_docs/version-v1.7/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/versioned_docs/version-v1.7/cli/vela_addon_registry_add.md
+++ b/versioned_docs/version-v1.7/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options

--- a/versioned_docs/version-v1.8/cli/vela_addon_registry_add.md
+++ b/versioned_docs/version-v1.8/cli/vela_addon_registry_add.md
@@ -16,8 +16,10 @@ vela addon registry add [flags]
 
 ```
 add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint=<URL>
-add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<ptah> --token=<git token>" 
+add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
+add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
+addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options
@@ -26,11 +28,11 @@ add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=
       --bucket string           specify the OSS bucket name
       --endpoint string         specify the addon registry endpoint
       --gitToken string         specify the github repo token
-      --gitlabRepoName string   specify the gitlab addon registry repoName
+      --gitlabRepoName string   specify the gitlab addon registry repoName, this option must be set when registry is gitlab
   -h, --help                    help for add
       --insecureSkipTLS         specify the Helm addon registry skip tls verify
       --password string         specify the Helm addon registry password
-      --path string             specify the addon registry OSS path
+      --path string             specify the addon registry path, this option must be set when addons are not in root of registry
       --type string             specify the addon registry type
       --username string         specify the Helm addon registry username
 ```

--- a/versioned_docs/version-v1.8/cli/vela_addon_registry_add.md
+++ b/versioned_docs/version-v1.8/cli/vela_addon_registry_add.md
@@ -19,7 +19,7 @@ add a helm repo registry: vela addon registry add --type=helm my-repo --endpoint
 add a github registry: vela addon registry add my-repo --type git --endpoint=<URL> --path=<path> --gitToken=<git token>
 add a specified github registry: vela addon registry add my-repo --type git --endpoint=https://github.com/kubevela/catalog --path=addons --gitToken=<git token>
 add a gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=<URL> --gitlabRepoName=<repoName> --path=<path> --token=<git token>
-addon a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.cmss.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
+add a specified gitlab registry: vela addon registry add my-repo --type gitlab --endpoint=http://gitlab.xxx.com/xxx/catalog --path=addons --gitlabRepoName=catalog --gitToken=<git token>
 ```
 
 ### Options


### PR DESCRIPTION
### Description of your changes
modify the registry usage examples for gitlab and github type so that users can use the registry more accurately and less error.
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
@wangyikewxgm 