### PR TITLE
(docs) Fixes broken links from install page

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -13,12 +13,12 @@ Please follow the document linked below to install KubeVela.
 - [Standalone Installation](./installation/standalone): Install KubeVela on a local machine or a remote server(Public Cloud or On-premise) based on Linux, macOS or Windows operating system.
 
 :::info
-VelaD suits great for local development and quick demos, it leverages [K3s](https://github.com/k3s-io/k3s) to manage Kubernetes. We strongly recommend you to [install KubeVela with managed Kubernetes services](./installation/kubernetes) for production usage.
+VelaD suits great for local development and quick demos, it leverages [K3s](https://github.com/k3s-io/k3s) to manage Kubernetes. We strongly recommend you to [install KubeVela with managed Kubernetes services](../installation/kubernetes) for production usage.
 :::
 
 ### Already have Kubernetes cluster
 - [Kubernetes Cluster](./installation/kubernetes): Install KubeVela in existing Kubernetes cluster.
 
 :::tip
-- For upgrading from existing KubeVela control plane, please read the [upgrade guide](./platform-engineers/advanced-install#upgrade).
+- For upgrading from existing KubeVela control plane, please read the [upgrade guide](../platform-engineers/advanced-install#upgrade).
 :::


### PR DESCRIPTION
### Description of your changes

This fixes the links for "Standalone Installation" and "Kubernetes Cluster" on https://kubevela.io/docs/install/ 


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [n/a] Update `sidebar.js` if adding a new page.
- [n/a] Run `yarn start` to ensure the changes has taken effect.

