### PR TITLE
Docs: comment acr.kubevela.net as deprecated

### DIFF
--- a/docs/reference/addons/velaux.md
+++ b/docs/reference/addons/velaux.md
@@ -286,9 +286,9 @@ By default the image repo is docker hub, you can specify the image repo by the `
 vela addon enable velaux repo=acr.kubevela.net
 ```
 
-You can try to specify the `acr.kubevela.net` image registry as an alternative, It's maintained by KubeVela team, and we will upload/sync the built-in addon image for convenience.
+Please note that `acr.kubevela.net` is **no longer maintained** and documented here just for example, in case you use `repo=your-registry.com`, the image to deploy velaux server will be `your-registry.com/oamdev/velaux:<velaux-version>`.
 
-This feature can also help you to build your private installation, just upload all images to your private image registry.
+This feature can help you to build your private installation, just upload all images to your private image registry.
 
 ## Concept of VelaUX
 


### PR DESCRIPTION
### Description of your changes

Update document of velaux to comment that `acr.kubevela.net` is deprecated and add explanatation to `repo` parameter.
See: https://github.com/kubevela/velaux/issues/879
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->