### PR TITLE
Docs: Add requirement for docker daemon to be running on standalone install

### DIFF
--- a/docs/installation/standalone.mdx
+++ b/docs/installation/standalone.mdx
@@ -40,6 +40,7 @@ VelaD support installing KubeVela on machines based on these OS: Linux, macOS, W
 
 1. If you are using Linux or macOS, make sure your machine have `curl` installed.
 2. If you are using macOS or Windows, make sure you've already installed [Docker](https://www.docker.com/products/docker-desktop).
+3. Make sure the docker daemon is up and running.
 
 ### 2. Install VelaD and Setup KubeVela
 

--- a/versioned_docs/version-v1.9/installation/standalone.mdx
+++ b/versioned_docs/version-v1.9/installation/standalone.mdx
@@ -40,6 +40,7 @@ VelaD support installing KubeVela on machines based on these OS: Linux, macOS, W
 
 1. If you are using Linux or macOS, make sure your machine have `curl` installed.
 2. If you are using macOS or Windows, make sure you've already installed [Docker](https://www.docker.com/products/docker-desktop).
+3. Make sure the docker daemon is up and running.
 
 ### 2. Install VelaD and Setup KubeVela
 


### PR DESCRIPTION
### Description of your changes

* Add a new pre-requirement for the docker daemon to be up and running before attempting and standalone installation.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

* Related to https://github.com/kubevela/velaux/issues/833