### PR TITLE
updated command for using postgres database as dbType for VelaUX

### DIFF
--- a/docs/reference/addons/velaux.md
+++ b/docs/reference/addons/velaux.md
@@ -232,7 +232,7 @@ After deployed, let's get the root password from the secret `vela-system/velaux-
 <TabItem label="PostgreSQL" value="postgresql">
 
 ```shell script
-vela addon enable velaux dbType=postgresql dbURL=postgres://<POSTGRESQL_USER>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<POSTGRESQL_DB_NAME>
+vela addon enable velaux dbType=postgres dbURL=postgres://<POSTGRESQL_USER>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<POSTGRESQL_DB_NAME>
 ```
 > It's necessary to create the specified database in advance.
 

--- a/versioned_docs/version-v1.10/reference/addons/velaux.md
+++ b/versioned_docs/version-v1.10/reference/addons/velaux.md
@@ -232,7 +232,7 @@ After deployed, let's get the root password from the secret `vela-system/velaux-
 <TabItem label="PostgreSQL" value="postgresql">
 
 ```shell script
-vela addon enable velaux dbType=postgresql dbURL=postgres://<POSTGRESQL_USER>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<POSTGRESQL_DB_NAME>
+vela addon enable velaux dbType=postgres dbURL=postgres://<POSTGRESQL_USER>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<POSTGRESQL_DB_NAME>
 ```
 > It's necessary to create the specified database in advance.
 


### PR DESCRIPTION
## Description

This pull request addresses an issue in the VelaUx setup documentation where an incorrect `dbType` parameter is specified for configuring the backend database with PostgreSQL. The current documentation instructs users to run:

```bash
vela addon enable velaux dbType=postgresql dbURL=postgres://<POSTGRESQL_USER>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<POSTGRESQL_DB_NAME>
```

However, executing this command results in the following error:
```
Error: render addon application fail: load app template with CUE files: parameter.dbType: 4 errors in empty disjunction: (and 4 more errors)
```
The error occurs because the parameter `dbType` is set to `postgresql`, whereas it should be set to `postgres` as per the source code cue template.

Changes: Modified the documentation command to use the correct dbType value.

Correct Command:

```
vela addon enable velaux dbType=postgres dbURL=postgres://<POSTGRESQL_USER>:<POSTGRESQL_PASSWORD>@<POSTGRESQL_HOST>:<POSTGRESQL_PORT>/<POSTGRESQL_DB_NAME>
```


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

Verified that the command now aligns with the expected parameters as defined in the source code cue template (refer to the attached image for more context).

![image (2)](https://github.com/user-attachments/assets/c1235867-96b7-4217-b34d-8b7bca04f67d)
