### PR TITLE
updated docs for ref-objects

### DIFF
--- a/docs/end-user/components/ref-objects.md
+++ b/docs/end-user/components/ref-objects.md
@@ -4,6 +4,8 @@ title: Distribute Reference Objects
 
 :::note
 This section requires you to know the basics about how to deploy [multi-cluster application](../../case-studies/multi-cluster.md) with policy and workflow.
+
+⚠️ **Important:** Since KubeVela v1.10, when referencing Kubernetes resources in `ref-objects`, you must explicitly specify the `group` field for resources outside the default groups (`core.oam.dev` and the empty group). Resources like `Deployment`, which belong to the `apps` group, require the `group` field to be explicitly declared.
 :::
 
 You can reference and distribute existing Kubernetes objects with KubeVela in the following scenarios:
@@ -81,6 +83,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
             cluster: hangzhou-1
             # select all deployment in the `examples` namespace in cluster `hangzhou-1` that matches the labelSelector
             labelSelector:
@@ -113,6 +116,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
           - resource: service
       traits:
         - type: scaler


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Updated the documentation to reflect the changes introduced in KubeVela v1.10, where you must explicitly specify the apiVersion field when referencing Kubernetes resources in ref-objects. This is necessary because KubeVela now only loads the default groups (core.oam.dev and ``), causing resources from other groups (e.g., apps/v1) to require explicit group declaration.

Reference: [Catalog PR #773](https://github.com/kubevela/catalog/pull/773)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->