### PR TITLE
fix/ updated docs for ref-objects

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/end-user/components/ref-objects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/end-user/components/ref-objects.md
@@ -4,6 +4,8 @@ title: 引用资源做多集群分发
 
 :::tip
 开始这部分之前需要你先了解使用如何进行多集群应用的部署。你可以参考 [多集群应用交付](../../case-studies/multi-cluster.md) 章节了解相关基础细节.
+
+⚠️ 重要： 自 KubeVela v1.10 起，在 ref-objects 中引用 Kubernetes 资源时，必须显式指定非默认组（core.oam.dev 和空组）资源的 group 字段。例如，属于 apps 组的 Deployment 资源，需要显式声明 group 字段。
 :::
 
 你可以使用 KubeVela 引用已有的 Kubernetes 对象并将它们分发到其他位置来完成以下场景：
@@ -77,6 +79,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
             cluster: hangzhou-1
             # select all deployment in the `examples` namespace in cluster `hangzhou-1` that matches the labelSelector
             labelSelector:
@@ -107,6 +110,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
           - resource: service
       traits:
         - type: scaler
@@ -139,6 +143,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
           - resource: service
       traits:
         - type: scaler

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.10/end-user/components/ref-objects.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.10/end-user/components/ref-objects.md
@@ -4,6 +4,8 @@ title: 引用资源做多集群分发
 
 :::tip
 开始这部分之前需要你先了解使用如何进行多集群应用的部署。你可以参考 [多集群应用交付](../../case-studies/multi-cluster.md) 章节了解相关基础细节.
+
+⚠️ 重要： 自 KubeVela v1.10 起，在 ref-objects 中引用 Kubernetes 资源时，必须显式指定非默认组（core.oam.dev 和空组）资源的 group 字段。例如，属于 apps 组的 Deployment 资源，需要显式声明 group 字段。
 :::
 
 你可以使用 KubeVela 引用已有的 Kubernetes 对象并将它们分发到其他位置来完成以下场景：
@@ -77,6 +79,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
             cluster: hangzhou-1
             # select all deployment in the `examples` namespace in cluster `hangzhou-1` that matches the labelSelector
             labelSelector:
@@ -107,6 +110,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
           - resource: service
       traits:
         - type: scaler
@@ -139,6 +143,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
           - resource: service
       traits:
         - type: scaler

--- a/versioned_docs/version-v1.10/end-user/components/ref-objects.md
+++ b/versioned_docs/version-v1.10/end-user/components/ref-objects.md
@@ -4,6 +4,8 @@ title: Distribute Reference Objects
 
 :::note
 This section requires you to know the basics about how to deploy [multi-cluster application](../../case-studies/multi-cluster.md) with policy and workflow.
+
+⚠️ **Important:** Since KubeVela v1.10, when referencing Kubernetes resources in `ref-objects`, you must explicitly specify the `group` field for resources outside the default groups (`core.oam.dev` and the empty group). Resources like `Deployment`, which belong to the `apps` group, require the `group` field to be explicitly declared.
 :::
 
 You can reference and distribute existing Kubernetes objects with KubeVela in the following scenarios:
@@ -81,6 +83,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
             cluster: hangzhou-1
             # select all deployment in the `examples` namespace in cluster `hangzhou-1` that matches the labelSelector
             labelSelector:
@@ -113,6 +116,7 @@ spec:
       properties:
         objects:
           - resource: deployment
+            group: apps
           - resource: service
       traits:
         - type: scaler


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Updated the documentation to reflect the changes introduced in KubeVela v1.10, where you must explicitly specify the group field when referencing Kubernetes resources in ref-objects. This is necessary because KubeVela now only loads the default groups (core.oam.dev and ``), causing resources from other groups (e.g., apps/v1) to require explicit group declaration.

Reference: https://github.com/kubevela/catalog/pull/773

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->