### PR TITLE
updated documentation for setting resources limit value for webservic…

### DIFF
--- a/versioned_docs/version-v1.10/end-user/components/references.md
+++ b/versioned_docs/version-v1.10/end-user/components/references.md
@@ -767,7 +767,11 @@ spec:
         ports:
           - port: 8080
             expose: true
-        cpu: "0.1"
+        cpu: "2"
+        memory: "500Mi"
+        limit:
+          cpu: "5"
+          memory: "1000Mi"
         env:
           - name: FOO
             value: bar
@@ -794,6 +798,7 @@ spec:
  env | Define arguments by using environment variables. | [[]env](#env-webservice) | false |  
  cpu | Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core). | string | false |  
  memory | Specifies the attributes of the memory resource required for the container. | string | false |  
+ limit | Specifies the limit of CPU and memory for resources | [limit](#limit-webservice)| false |
  volumeMounts |  | [volumeMounts](#volumemounts-webservice) | false |  
  volumes | Deprecated field, use volumeMounts instead. | [[]volumes](#volumes-webservice) | false |  
  livenessProbe | Instructions for assessing whether the container is alive. | [livenessProbe](#livenessprobe-webservice) | false |  
@@ -1038,5 +1043,12 @@ spec:
  ---- | ----------- | ---- | -------- | ------- 
  ip |  | string | true |  
  hostnames |  | []string | true |  
+
+#### limit (webservice)
+
+ Name | Description | Type | Required | Default 
+ ---- | ----------- | ---- | -------- | ------- 
+ cpu | Number of CPU units for the service, like `0.5` (0.5 CPU core), `1` (1 CPU core).       | string                                       | false |
+ memory | Specifies the attributes of the memory resource required for the container.             | string                                       | false |
 
 


### PR DESCRIPTION
Description of your changes

Updated the documentation to reflect the changes to modify the webservice component definition to allow independent configuration of resources requests and limits for CPU/memory. Users can define these parameters separately to better align with specific environment needs.

Reference: 
    https://github.com/kubevela/kubevela/pull/6714
    https://github.com/kubevela/kubevela/issues/6704


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.