### PR TITLE
Change from .net to .io references

### DIFF
--- a/docs/end-user/traits/rollout.md
+++ b/docs/end-user/traits/rollout.md
@@ -81,7 +81,7 @@ Services:
       ✅ scaler      ✅ gateway: No loadBalancer found, visiting by using 'vela port-forward canary-demo'
 ```
 
-If you have enabled [velaux](../../reference/addons/velaux.md) addon, you can view the application topology graph that all `v1` pods are ready now.
+If you have enabled [velaux](../../reference/addons/velaux.md) addon, you can view the application topology graph that all `v1` pods are ready now by navigating to canary-demo->Workflows->Status. 
 
 ![image](../../resources/kruise-rollout-v1.jpg)
 

--- a/docs/end-user/traits/rollout.md
+++ b/docs/end-user/traits/rollout.md
@@ -47,6 +47,11 @@ The first deployment is a default way to deploy an application. You can check th
 
 ```shell
 $ vela status canary-demo
+```
+
+The expected output:
+
+```shell
 About:
 
   Name:         canary-demo                  

--- a/docs/getting-started/definition.md
+++ b/docs/getting-started/definition.md
@@ -157,7 +157,7 @@ spec:
 Use the definition in `vela` command line works the same, you can compose the application yaml manually and deploy by `vela up` command.
 
 ```
-vela up -f https://kubevela.net/example/applications/first-app.yaml
+vela up -f https://kubevela.io/example/applications/first-app.yaml
 ```
 
 Application is also one kind of Kubernetes CRD, you can also use `kubectl apply` or invoke Kubernetes API to integrate with vela application.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -84,7 +84,7 @@ environment prod with namespace prod created
 * Starting to deploy the application
 
 ```
-vela up -f https://kubevela.net/example/applications/first-app.yaml
+vela up -f https://kubevela.io/example/applications/first-app.yaml
 ```
 
 <details>

--- a/docs/tutorials/custom-image-delivery.md
+++ b/docs/tutorials/custom-image-delivery.md
@@ -11,7 +11,7 @@ If so, you could change the `webservice` definition.
 
 1. Change the UI schema to hide some fields
 
-> This way is only suitable the UI users.
+> This way is only suitable for the UI users.
 
 ![image](https://static.kubevela.net/images/1.5/custom-ui-schema.jpg)
 
@@ -38,7 +38,7 @@ If you want to completely remove or add some fields, you should edit the compone
 vela def get webservice > custom-webservice.cue
 ```
 
-Refer to the [CUE Basic](../platform-engineers/cue/basic.md) and [Component Definition](../platform-engineers/components/custom-component.md) documents to learn how to custom the `custom-webservice.cue`.
+Refer to the [CUE Basic](../platform-engineers/cue/basic.md) and [Component Definition](../platform-engineers/components/custom-component.md) documents to learn how to customise the `custom-webservice.cue`.
 
 After edit:
 


### PR DESCRIPTION
### Description of your changes

<!--

Changes the reference of  kubevela.net to kubevela.io. 

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the quick start guide to use kubevela.io instead of kubevela.net in the example application URL.

<!-- End of auto-generated description by cubic. -->

