### PR TITLE
Fix: Documentation for versioning of definitions

### DIFF
--- a/docs/end-user/definition-version-control.md
+++ b/docs/end-user/definition-version-control.md
@@ -147,7 +147,7 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
 
 ## Adding a `version` Field in CUE-based Definitions
-Include the version field immediately below the attributes section in your .cue file to enable semantic versioning. If you do not require semantic versioning, you may omit the version field.
+Include the version field inside the attributes section in your .cue file to enable semantic versioning. If you do not require semantic versioning, you may omit the version field.
 Example:
 ```
 "configmap-creater": {

--- a/docs/end-user/definition-version-control.md
+++ b/docs/end-user/definition-version-control.md
@@ -147,7 +147,7 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
 
 ## Adding a `version` Field in CUE-based Definitions
-The version field should be placed directly under the spec section (i.e., spec.version). To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
+The version field should be placed directly under the attributes section. To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
 
 Example:
 ```

--- a/docs/end-user/definition-version-control.md
+++ b/docs/end-user/definition-version-control.md
@@ -56,7 +56,8 @@ spec:
 ```
 
 2. Create a `configmap-component` ComponentDefinition with `2.0.5` version
-```apiVersion: core.oam.dev/v1beta1
+```
+apiVersion: core.oam.dev/v1beta1
 kind: ComponentDefinition
 metadata:
   name: configmap-component
@@ -90,7 +91,8 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ```
 
 4. Create Application using `configmap-component@v1.2` version and enable the Auto Update using `app.oam.dev/autoUpdate` annotation.
-```apiVersion: core.oam.dev/v1beta1
+```
+apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
   name: test-app
@@ -143,3 +145,39 @@ my-component-v1.2.5                1          1a4f3ac77e4fcfef   Component
 my-component-v1.2.7                3          86d7fb1a36566dea   Component
 my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
+
+## Adding a `version` Field in CUE-based Definitions
+The version field should be placed directly under the spec section (i.e., spec.version). To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
+
+Example:
+```
+"configmap-creater": {
+    type: "component"
+    attributes: {
+        workload: definition: {
+            apiVersion: "v1"
+            kind:       "ConfigMap"
+        }
+        version: "1.1.1"
+    }
+}
+
+template: {
+    output: {
+        apiVersion: "v1"
+        kind:       "ConfigMap"
+        metadata: {
+            name: parameter.name
+            namespace: context.namespace
+        }
+        data: parameter.data
+    }
+
+    parameter: {
+        // +usage=Name of the ConfigMap.
+        name: string
+        // +usage=Data to be stored in the ConfigMap.
+        data: [string]: string
+    }
+}
+```

--- a/docs/end-user/definition-version-control.md
+++ b/docs/end-user/definition-version-control.md
@@ -147,8 +147,7 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
 
 ## Adding a `version` Field in CUE-based Definitions
-The version field should be placed directly under the attributes section. To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
-
+Include the version field immediately below the attributes section in your .cue file to enable semantic versioning. If you do not require semantic versioning, you may omit the version field.
 Example:
 ```
 "configmap-creater": {

--- a/versioned_docs/version-v1.10/end-user/definition-version-control.md
+++ b/versioned_docs/version-v1.10/end-user/definition-version-control.md
@@ -147,7 +147,7 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
 
 ## Adding a `version` Field in CUE-based Definitions
-Include the version field immediately below the attributes section in your .cue file to enable semantic versioning. If you do not require semantic versioning, you may omit the version field.
+Include the version field inside the attributes section in your .cue file to enable semantic versioning. If you do not require semantic versioning, you may omit the version field.
 Example:
 ```
 "configmap-creater": {

--- a/versioned_docs/version-v1.10/end-user/definition-version-control.md
+++ b/versioned_docs/version-v1.10/end-user/definition-version-control.md
@@ -147,7 +147,7 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
 
 ## Adding a `version` Field in CUE-based Definitions
-The version field should be placed directly under the spec section (i.e., spec.version). To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
+The version field should be placed directly under the attributes section. To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
 
 Example:
 ```

--- a/versioned_docs/version-v1.10/end-user/definition-version-control.md
+++ b/versioned_docs/version-v1.10/end-user/definition-version-control.md
@@ -56,7 +56,8 @@ spec:
 ```
 
 2. Create a `configmap-component` ComponentDefinition with `2.0.5` version
-```apiVersion: core.oam.dev/v1beta1
+```
+apiVersion: core.oam.dev/v1beta1
 kind: ComponentDefinition
 metadata:
   name: configmap-component
@@ -90,7 +91,8 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ```
 
 4. Create Application using `configmap-component@v1.2` version and enable the Auto Update using `app.oam.dev/autoUpdate` annotation.
-```apiVersion: core.oam.dev/v1beta1
+```
+apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:
   name: test-app
@@ -143,3 +145,39 @@ my-component-v1.2.5                1          1a4f3ac77e4fcfef   Component
 my-component-v1.2.7                3          86d7fb1a36566dea   Component
 my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
+
+## Adding a `version` Field in CUE-based Definitions
+The version field should be placed directly under the spec section (i.e., spec.version). To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
+
+Example:
+```
+"configmap-creater": {
+    type: "component"
+    attributes: {
+        workload: definition: {
+            apiVersion: "v1"
+            kind:       "ConfigMap"
+        }
+        version: "1.1.1"
+    }
+}
+
+template: {
+    output: {
+        apiVersion: "v1"
+        kind:       "ConfigMap"
+        metadata: {
+            name: parameter.name
+            namespace: context.namespace
+        }
+        data: parameter.data
+    }
+
+    parameter: {
+        // +usage=Name of the ConfigMap.
+        name: string
+        // +usage=Data to be stored in the ConfigMap.
+        data: [string]: string
+    }
+}
+```

--- a/versioned_docs/version-v1.10/end-user/definition-version-control.md
+++ b/versioned_docs/version-v1.10/end-user/definition-version-control.md
@@ -147,8 +147,7 @@ my-component-v2.5.0                2          e61e9b5e55b01c2b   Component
 ````
 
 ## Adding a `version` Field in CUE-based Definitions
-The version field should be placed directly under the attributes section. To enable semantic versioning in CUE based definitions, specify the version field under the attributes section in the .cue file.
-
+Include the version field immediately below the attributes section in your .cue file to enable semantic versioning. If you do not require semantic versioning, you may omit the version field.
 Example:
 ```
 "configmap-creater": {


### PR DESCRIPTION
Fix: Documentation for versioning of definitions and add example for cue files

### Description of your changes

Added the documentation example for versioning of definitions for .cue files

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the documentation to explain versioning for definitions and added a CUE file example showing how to set the version field.

<!-- End of auto-generated description by cubic. -->

