### PR TITLE
Fix: Unbundle the X-Definition Validation from Authentication Feature…

### DIFF
--- a/docs/platform-engineers/auth/definition-rbac.md
+++ b/docs/platform-engineers/auth/definition-rbac.md
@@ -12,17 +12,14 @@ Definition Permission Validation ensures users can only reference X-Definitions 
 
 ## Enabling the Feature
 
-The feature requires two flags when installing or upgrading KubeVela:
+The feature requires the `authorization.definitionValidationEnabled` flag to be enabled when installing or upgrading KubeVela:
 
 ```bash
 helm upgrade --install kubevela kubevela/vela-core \
   --namespace vela-system \
-  --set authentication.enabled=true \
-  --set authentication.definitions.enabled=true \
+  --set authorization.definitionValidationEnabled=true \
   --wait
 ```
-
-Both `authentication.enabled` and `authentication.definitions.enabled` must be true.
 
 > **Note:** This feature is disabled by default. Before enabling, ensure your users have appropriate RBAC permissions to access the definitions they need.
 
@@ -179,10 +176,8 @@ kubectl auth can-i get componentdefinitions.core.oam.dev/custom-component -n my-
 ### Helm Values
 
 ```yaml
-authentication:
-  enabled: true        # Enable authentication framework (required)
-  definitions:
-    enabled: true      # Enable definition permission validation
+authorization:
+  definitionValidationEnabled: true
 ```
 
 ### Controller Flags
@@ -190,7 +185,6 @@ authentication:
 For non-Helm deployments:
 
 ```bash
---authentication-with-user=true
 --feature-gates=ValidateDefinitionPermissions=true
 ```
 


### PR DESCRIPTION
…s (#6904)

### Description of your changes

Documents fix changes made in https://github.com/kubevela/kubevela/pull/6904/checks for issue https://github.com/kubevela/kubevela/issues/6893

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated Definition RBAC docs to reflect that Definition Permission Validation is no longer bundled with authentication. It’s now enabled via authorization.definitionValidationEnabled; Helm values updated and the --authentication-with-user controller flag removed.

<!-- End of auto-generated description by cubic. -->

