### PR TITLE
Chore: Remove unused parameter 'addonName' from 'vela-cli' workflow s…

### DIFF
--- a/docs/end-user/workflow/built-in-workflow-defs.md
+++ b/docs/end-user/workflow/built-in-workflow-defs.md
@@ -3056,7 +3056,6 @@ spec:
 
  Name | Description | Type | Required | Default 
  ---- | ----------- | ---- | -------- | ------- 
- addonName | Specify the name of the addon. | string | true |  
  command | Specify the vela command. | []string | true |  
  image | Specify the image. | string | false | oamdev/vela-cli:v1.6.4 
  serviceAccountName | specify serviceAccountName want to use. | string | false | kubevela-vela-core 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/end-user/workflow/built-in-workflow-defs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/end-user/workflow/built-in-workflow-defs.md
@@ -3056,7 +3056,6 @@ spec:
 
  名称 | 描述 | 类型 | 是否必须 | 默认值 
  ------ | ------ | ------ | ------------ | --------- 
- addonName | Specify the name of the addon。 | string | true |  
  command | Specify the vela command。 | []string | true |  
  image | Specify the image。 | string | false | oamdev/vela-cli:v1.6.4 
  serviceAccountName | specify serviceAccountName want to use。 | string | false | kubevela-vela-core 


### PR DESCRIPTION
### Description of your changes

Update documentation to remove the unused `addonName` parameter from the `vela-cli` workflow step, to match this core PR: https://github.com/kubevela/kubevela/pull/6930

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page. -- NA
- [x] Run `yarn start` to ensure the changes has taken effect.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the unused addonName parameter from the vela-cli workflow step documentation (EN/zh) to match current core behavior and avoid confusion.

<!-- End of auto-generated description by cubic. -->

