### PR TITLE
docs: correct Helm values section to use featureGates for resource va…

### DIFF
--- a/versioned_docs/version-v1.10/platform-engineers/cue/validate-definition-output-resources.md
+++ b/versioned_docs/version-v1.10/platform-engineers/cue/validate-definition-output-resources.md
@@ -30,8 +30,8 @@ kubectl -n vela-system get deploy kubevela-controller \
 
 ```yaml
 # Helm values for vela-core
-features:
-  ValidateResourcesExist: true  # Default: false (Alpha)
+featureGates:
+  validateResourcesExist: true  # Default: false (Alpha)
 ```
 
 > 


### PR DESCRIPTION
…lidation

### Description of your changes
Fixes a wrong documentation for enabling validate resource exists 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Corrected the Helm values example to use featureGates.validateResourcesExist for enabling resource existence validation in vela-core. This fixes the wrong key in the docs so the setting is applied correctly.

<!-- End of auto-generated description by cubic. -->

