### PR TITLE
docs: fix spelling and grammar errors in k8s-object tutorial

### DIFF
--- a/docs/tutorials/k8s-object.mdx
+++ b/docs/tutorials/k8s-object.mdx
@@ -124,7 +124,7 @@ vela up -f https://kubevela.io/example/applications/app-with-k8s-objects.yaml
 vela status app-with-k8s-objects
 ```
 
-You can also check the deployment and service with the `kubectl` or any other tools you familiar to check the deployment.
+You can also check the deployment and service with the `kubectl` or any other tools you are familiar with to check the deployment.
 
 - Approve the workflow if everything looks good.
 
@@ -181,7 +181,7 @@ As for the test environment, it sure can be updated at any time. When we update 
 
 ### Deploying prod environment
 
-Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely dependant on each other, of each is an individual Application CR.
+Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely independent of each other, as each is an individual Application CR.
 
 As we have two targets for the prod environment, it'll execute in sequence. If you hope to set up a manual approval before it gets into the second target, this is where workflow comes in.
 

--- a/versioned_docs/version-v1.10/tutorials/k8s-object.mdx
+++ b/versioned_docs/version-v1.10/tutorials/k8s-object.mdx
@@ -124,7 +124,7 @@ vela up -f https://kubevela.io/example/applications/app-with-k8s-objects.yaml
 vela status app-with-k8s-objects
 ```
 
-You can also check the deployment and service with the `kubectl` or any other tools you familiar to check the deployment.
+You can also check the deployment and service with the `kubectl` or any other tools you are familiar with to check the deployment.
 
 - Approve the workflow if everything looks good.
 
@@ -181,7 +181,7 @@ As for the test environment, it sure can be updated at any time. When we update 
 
 ### Deploying prod environment
 
-Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely dependant on each other, of each is an individual Application CR.
+Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely independent of each other, as each is an individual Application CR.
 
 As we have two targets for the prod environment, it'll execute in sequence. If you hope to set up a manual approval before it gets into the second target, this is where workflow comes in.
 

--- a/versioned_docs/version-v1.7/tutorials/k8s-object.mdx
+++ b/versioned_docs/version-v1.7/tutorials/k8s-object.mdx
@@ -124,7 +124,7 @@ vela up -f https://kubevela.io/example/applications/app-with-k8s-objects.yaml
 vela status app-with-k8s-objects
 ```
 
-You can also check the deployment and service with the `kubectl` or any other tools you familiar to check the deployment.
+You can also check the deployment and service with the `kubectl` or any other tools you are familiar with to check the deployment.
 
 - Approve the workflow if everything looks good.
 
@@ -181,7 +181,7 @@ As for the test environment, it sure can be updated at any time. When we update 
 
 ### Deploying prod environment
 
-Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely dependant on each other, of each is an individual Application CR.
+Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely independent of each other, as each is an individual Application CR.
 
 As we have two targets for the prod environment, it'll execute in sequence. If you hope to set up a manual approval before it gets into the second target, this is where workflow comes in.
 

--- a/versioned_docs/version-v1.8/tutorials/k8s-object.mdx
+++ b/versioned_docs/version-v1.8/tutorials/k8s-object.mdx
@@ -124,7 +124,7 @@ vela up -f https://kubevela.io/example/applications/app-with-k8s-objects.yaml
 vela status app-with-k8s-objects
 ```
 
-You can also check the deployment and service with the `kubectl` or any other tools you familiar to check the deployment.
+You can also check the deployment and service with the `kubectl` or any other tools you are familiar with to check the deployment.
 
 - Approve the workflow if everything looks good.
 
@@ -181,7 +181,7 @@ As for the test environment, it sure can be updated at any time. When we update 
 
 ### Deploying prod environment
 
-Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely dependant on each other, of each is an individual Application CR.
+Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely independent of each other, as each is an individual Application CR.
 
 As we have two targets for the prod environment, it'll execute in sequence. If you hope to set up a manual approval before it gets into the second target, this is where workflow comes in.
 

--- a/versioned_docs/version-v1.9/tutorials/k8s-object.mdx
+++ b/versioned_docs/version-v1.9/tutorials/k8s-object.mdx
@@ -124,7 +124,7 @@ vela up -f https://kubevela.io/example/applications/app-with-k8s-objects.yaml
 vela status app-with-k8s-objects
 ```
 
-You can also check the deployment and service with the `kubectl` or any other tools you familiar to check the deployment.
+You can also check the deployment and service with the `kubectl` or any other tools you are familiar with to check the deployment.
 
 - Approve the workflow if everything looks good.
 
@@ -181,7 +181,7 @@ As for the test environment, it sure can be updated at any time. When we update 
 
 ### Deploying prod environment
 
-Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely dependant on each other, of each is an individual Application CR.
+Let's switch to the Tab of the prod environment. It shows that it's not deployed yet. So now you can understand one basic thing for KubeVela, different environments in one application are completely independent of each other, as each is an individual Application CR.
 
 As we have two targets for the prod environment, it'll execute in sequence. If you hope to set up a manual approval before it gets into the second target, this is where workflow comes in.
 


### PR DESCRIPTION
Fixed two errors in the Kubernetes object deployment tutorial:
1. Line 127: Changed "tools you familiar to check" to "tools you are familiar with to check"
2. Line 184: Changed "completely dependant on each other, of each is" to "completely independent of each other, as each is"
   - Corrected misspelling: "dependant" → "independent"
   - Fixed semantic error: environments are independent, not dependent
   - Improved grammar: "of each is" → "as each is"

These fixes have been applied to all documentation versions:
- docs/tutorials/k8s-object.mdx (current)
- versioned_docs/version-v1.10/tutorials/k8s-object.mdx
- versioned_docs/version-v1.9/tutorials/k8s-object.mdx
- versioned_docs/version-v1.8/tutorials/k8s-object.mdx
- versioned_docs/version-v1.7/tutorials/k8s-object.mdx


I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed two wording and grammar issues in the Kubernetes object deployment tutorial to improve clarity. Changes are applied across all versioned docs (v1.7–v1.10).

- **Bug Fixes**
  - "tools you familiar to check" → "tools you are familiar with to check"
  - "completely dependant on each other, of each is" → "completely independent of each other, as each is"

<!-- End of auto-generated description by cubic. -->

