### PR TITLE
Blog: Release 1.10.4

### DIFF
--- a/blog/2025-10-20-release-1.10.4.md
+++ b/blog/2025-10-20-release-1.10.4.md
@@ -1,0 +1,150 @@
+---
+---
+title: KubeVela 1.10.4 Now Available 
+author: Brian Kane
+author_title: KubeVela Team
+author_url: https://github.com/briankane
+author_image_url: https://KubeVela.io/img/logo.svg
+tags: [ KubeVela, release-note, Kubernetes, DevOps, CNCF, CI/CD, Application delivery, Role-Based Access Control, Telemetry]
+description: "This article discusses the changes released in the latest v1.10.4 release"
+image: https://raw.githubusercontent.com/oam-dev/KubeVela.io/main/docs/resources/KubeVela-03.png
+hide_table_of_contents: false
+---
+
+**Hello community!** 👋
+
+This is the first blog post in a while but we are excited to reinvigorate the community and keep developers and users up to date with all things KubeVela. The team is committed to providing regular updates, news and information about upcoming events and features.
+
+We recently released the latest v1.10.4 which includes a host of useful features to improve the maintainability of Applications deployed with Kubevela. This blog will provide a quick overview of the features and how you can get started with utilising them in your KubeVela setup. 
+
+# New Features
+While v1.10.4 follows semantic versioning as a patch release, we're excited to deliver several new opt-in features alongside the usual bug fixes and improvements. 
+
+These features are disabled by default (where applicable) to maintain backward compatibility, allowing users to adopt them at their own pace.
+
+<!--truncate-->
+## Kubernetes 1.31 Support 
+The team have put huge efforts into completing the support for Kubernetes v1.31 across all KubeVela repositories. 
+
+Users can now confidently run KubeVela on Kubernetes 1.31 with all core functionality validated. 
+
+<!--truncate-->
+
+## Resource Existence Validation
+KubeVela users can now validate that the resources being created by their definitions are present on the cluster ahead of deployment of the Application. This new feature will work across Component, Trait, Policy and WorkflowStep definitions to reduce runtime errors and improve the overall reliability of KubeVela deployments.
+
+To get started, developers can set `ValidateResourcesExist` feature flag in their installations. 
+
+See [PR 6932](https://github.com/kubevela/kubevela/pull/6932) for more information.
+
+<!--truncate-->
+
+## Native Cue in Health Fields
+Developers writing workload definitions can now add status attributes in native cue, rather than nested strings. Behind the scenes, the string and cue conversions happen automatically and include some new validations of the attribute types and the presence of required fields. 
+
+This feature is enabled by default; but you'll need to ensure to use the latest version of the KubeVela CLI to take advantage of cue formatting. String formatting is completely backwards compatible.
+
+See [PR 6859](https://github.com/kubevela/kubevela/pull/6859) for more information.
+
+<!--truncate-->
+
+## Enhanced Status Reporting
+Applications had two primary means to communicate status - the [Health Check](https://kubevela.io/docs/next/platform-engineers/status/definition_health_status/#2-health-check---overall-health-indicator) and [Custom Message](https://kubevela.io/docs/next/platform-engineers/status/definition_health_status/#2-health-check---overall-health-indicator). Whilst these provide an insight into the overall health of the application and give a succinct human readable summary of current state - we had feedback from developers that they required a longer lived, more detailed way to capture information about managed resources. 
+
+Hence, we added the new [Status Details](https://kubevela.io/docs/next/platform-engineers/status/definition_health_status/#1-status-details---structured-diagnostic-information) field that can capture a map of any information developers feel is useful for reporting on, debugging or observing their components & traits. 
+
+It uses familiar cue syntax to extract information and has access to the full KubeVela context already accessible in Health Checks and Custom Messages.
+
+For example, from the docs:
+
+```
+attributes: status: details: {
+    readyReplicas: context.output.status.readyReplicas
+    totalReplicas: context.output.spec.replicas
+    readyPercentage: (context.output.status.readyReplicas / context.output.spec.replicas) * 100
+    deploymentMode: context.output.spec.strategy.type
+}
+```
+
+will provide users with the following in their Application status, allowing for better abstraction from the underlying resource.
+```
+status:
+  services:
+    - name: my-service
+      status:
+        readyReplicas: "3"
+        totalReplicas: "3"
+        readyPercentage: "100"
+        deploymentMode: "RollingUpdate"
+```
+
+Better still - we've put work into unifying the various status evaluators. The fields captured in Status Details are made available in the Health Check and Custom Message (via `context.status.details`) so that logic can be better reused. See [How Status Evaluation Works](https://kubevela.io/docs/next/platform-engineers/status/definition_health_status/#how-status-evaluation-works) for full details of the changes.
+
+See [PR 6828](https://github.com/kubevela/kubevela/pull/6828) or the [revised documentation](https://kubevela.io/docs/next/platform-engineers/status/definition_health_status) for more information.
+
+<!--truncate-->
+
+## Application Status Metrics
+As part of the fix in [PR 6824](https://github.com/kubevela/kubevela/pull/6824) we now ensures that Application health is continuously evaluated, even after the workflow succeeds.
+
+To compliment this, we've added additional application level metrics so that operators can have simplified visibility into the status of their Applications.  
+
+These are the:
+- `kubevela_application_health_status{app_name, namespace}`
+- `kubevela_application_phase{app_name, namespace}`
+- `kubevela_application_workflow_phase{app_name, namespace}`
+
+We've made efforts to ensure these are low cardinality through numeric phase mapping - so operators should be able to collect and monitor these cost effectively in their monitoring solutions. 
+
+To add more depth to monitoring capabilities, we've also added structured logging when Application changes occur. These logs capture the Application state in a high detail of detail to supplement the new metrics.
+
+The full structure of these logs can be found [here](https://kubevela.io/docs/next/platform-engineers/status/application_health_status_metrics/#structured-logging)
+
+To get started, users can enable the EnableApplicationStatusMetrics feature gate to activate both metrics and the new structured logging.
+
+See [PR 6857](https://github.com/kubevela/kubevela/pull/6857) or the [documentation](https://kubevela.io/docs/next/platform-engineers/status/application_health_status_metrics/) for more information.
+
+<!--truncate-->
+
+## Dependency-Aware Workflows
+[Issue 6852](https://github.com/kubevela/kubevela/issues/6852) raised the issue with the confusion of DependsOn [within components](https://kubevela.io/docs/end-user/workflow/component-dependency-parameter/#dependency), and DependsOn [within workflows](https://kubevela.io/docs/end-user/workflow/dependency/#how-to-use) - and how workflows did not natively respect component dependencies. 
+
+KubeVela will now dynamically add workflow dependencies between steps according to the components dependencies; which is vastly simplified and much more in line with user expectations. 
+
+See [PR 6854](https://github.com/kubevela/kubevela/pull/6854) for more information. 
+
+<!--truncate-->
+
+## Colorised Logging Support
+We've introduced opt-in support for colorised logging to improve the developer debugging experience. 
+
+For local development, developers can use the new `--dev-logs` to enable this for their console output.
+
+This feature is **not** recommended for production & CI usage and is disabled by default. When disabled, existing log functionality is preserved.
+
+The log formatting enhancements include:
+- Color-coded structured fields (cyan for keys, grey for values)
+- Emphasized primary message text in bright white
+- Enriched location information (file:method:line)
+- Spring Boot-inspired formatting style
+
+See [PR 6931](https://github.com/kubevela/kubevela/pull/6931) for more information.
+
+<!--truncate-->
+<br />
+
+# Full Release Details
+Of course this blog doesn't capture all of the great work that went into this release. Our contributors have made amazing progress on fixing bugs, handling chore work, bolstering our test suites, providing feedback & issue reports, and much more. 
+
+So a huge thank you due to everyone who contributed during this (and all!) release cycles. The full details of the release can be found at [v1.10.4](https://github.com/kubevela/kubevela/releases/tag/v1.10.4)
+
+<!--truncate-->
+<br />
+
+# Give Us Your Feedback
+
+We are excited for the community to get their hands on these new features and encourage any feedback or contributions to keep improving KubeVela!
+
+Slack: [#kubevela](https://cloud-native.slack.com/archives/C01BLQ3HTJA) (English)
+
+Every week we host a [community meeting](https://github.com/kubevela/community?tab=readme-ov-file#community-meetings) to showcase new features, review upcoming milestones, and engage in a Q&A. All are welcome!


### PR DESCRIPTION
### Description of your changes

Adds blog post for Release v1.10.4

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Publish blog post announcing KubeVela 1.10.4, adding a new page with release highlights, docs links, and community info. Covers Kubernetes 1.31 support, resource existence validation, Cue-based health fields, enhanced status reporting and metrics, dependency-aware workflows, and optional colorized logs.

<!-- End of auto-generated description by cubic. -->

