### PR TITLE
Fix: Fix Dracula Theme Issues

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -163,7 +163,7 @@ module.exports = {
       `,
     },
     prism: {
-      theme: require('prism-react-renderer').themes.dracula,
+      theme: require('prism-react-renderer/themes/dracula'),
       additionalLanguages: ['cue', 'powershell'],
     },
     zoom: {
@@ -277,8 +277,7 @@ module.exports = {
           blogSidebarTitle: 'All posts',
           blogSidebarCount: 'ALL',
           showReadingTime: true,
-          editUrl: 'https://github.com/kubevela/kubevela.io/tree/main/',
-          onInlineAuthors: 'ignore',
+          editUrl: 'https://github.com/kubevela/kubevela.io/tree/main/'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),


### PR DESCRIPTION
### Description of your changes

Fixes `yarn start` issues with dracula theme:

```
[INFO] Starting the development server...
[ERROR] TypeError: Cannot read properties of undefined (reading 'dracula')
    at Object.<anonymous> (/Users/bkane/Development/OSS/kubevela/development/kubevela.github.io/docusaurus.config.js:166:52)
    at Module._compile (node:internal/modules/cjs/loader:1455:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1534:10)
    at Module.load (node:internal/modules/cjs/loader:1265:32)
    at Module._load (node:internal/modules/cjs/loader:1081:12)
    at Module.require (node:internal/modules/cjs/loader:1290:19)
    at module.exports (/Users/bkane/Development/OSS/kubevela/development/kubevela.github.io/node_modules/import-fresh/index.js:32:59)
    at loadSiteConfig (/Users/bkane/Development/OSS/kubevela/development/kubevela.github.io/node_modules/@docusaurus/core/lib/server/config.js:36:55)
    at async loadContext (/Users/bkane/Development/OSS/kubevela/development/kubevela.github.io/node_modules/@docusaurus/core/lib/server/index.js:31:63)
    at async load (/Users/bkane/Development/OSS/kubevela/development/kubevela.github.io/node_modules/@docusaurus/core/lib/server/index.js:74:21)
[INFO] Docusaurus version: 2.4.3
Node version: v22.0.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Update `sidebar.js` if adding a new page.
- [x] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the Docusaurus dev server crash by correctly loading the Prism Dracula theme and removing an unsupported blog option. This makes yarn start work again on Docusaurus 2.4.3.

- **Bug Fixes**
  - Load Prism Dracula via require('prism-react-renderer/themes/dracula') to avoid undefined themes.
  - Remove onInlineAuthors from blog config, which is not supported.

<!-- End of auto-generated description by cubic. -->

