### PR TITLE
docs: Add 2026 spring roadmap documentation

### DIFF
--- a/docs/roadmap/2026-03-roadmap.md
+++ b/docs/roadmap/2026-03-roadmap.md
@@ -1,0 +1,25 @@
+---
+title:  Roadmap 2026.03
+---
+
+Date: 2026-01-01 to 2026-03-31
+
+## Core Platform
+
+- Native Helm Chart Support
+  * Make Helm a first class citizen within KubeVela, adding native support through CueX and a supporting helmchart component. 
+  * This will allow KubeVela to deploy Helm Charts directly, without the need for external tools or addons like FluxCD and will use the existing KubeVela multi-cluster dispatch system for better awareness of the underlying managed resources within KubeVela. 
+- Definition Quality Improvements
+  * Review all definitions with focus on workflow steps. Validate definitions work in both Applications and WorkflowRuns. 
+  * Add test cases for each definition, ensure all definitions are working as intended and re-establish consistency between Applications and WorkflowRuns.
+- Testing Infrastructure Enhancement
+  * Improve E2E test suite for faster and more reliable releases. Add better test coverage and automation.
+
+
+## Best practices and community
+
+- Community Growth Program
+  * Create clear contributor guidelines and recognition system. 
+  * Add more examples to the repository showing real use cases. 
+  * Make it easier to contribute components and traits with better templates. 
+  * Remove outdated documentation and update examples to current versions.


### PR DESCRIPTION

### Description of your changes

<!--

-->

- This PR adds new roadmap documentation for 2026 Spring (Date: 2026-01-01 to 2026-03-31)
- Added 2026-03-roadmap.md with planned features


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the 2026 Spring roadmap (Jan 1–Mar 31, 2026) in docs/roadmap/2026-03-roadmap.md.
Focus areas: native Helm chart support via CueX and a helmchart component, definition quality improvements across Applications and WorkflowRuns, faster and more reliable E2E testing, and a community growth program.

<sup>Written for commit e7b813a3fa420fef93afbc4994ff9860e1cdcdf5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



