### PR TITLE
 docs: Add 2026 summer roadmap documentation 

### DIFF
--- a/docs/roadmap/2026-06-roadmap.md
+++ b/docs/roadmap/2026-06-roadmap.md
@@ -1,0 +1,24 @@
+---
+title:  Roadmap 2026.06
+---
+
+Date: 2026-04-01 to 2026-06-30
+
+## Core Platform
+
+- Config Validation via Webhooks
+  * Replace CLI validation with webhook-based approach to guarantee the integrity of configuration files and ensure that configuration cannot bypass validations. 
+  * This will ensure better integration with GitOps practices, reduce misconfiguration in deployments and enhance KubeVela configurations ability to act as a foundation for future enhancements.
+
+- Config Provider Definition
+  * Add support for validated and type safe definitions (via ConfigTemplates) for data/configuration retrieval. 
+  * This would support the existing definitions and allow for more dynamic configuration of Applications. 
+  * These definitions would be written in familiar cue syntax with CueX powering the ability to retrieve configuration from external systems and other resources. 
+
+- Declarative Addons
+  * Allow Addons to be installed and managed declaratively to better enable their usage within GitOps workflows.
+
+## Third-party integrations and addons
+
+- Addon Ecosystem Refresh
+  * Modernize and clean up the Addon catalog to ensure better stability and feature compatibility with the latest cloud and Kubernetes versions. 


### PR DESCRIPTION
docs: add 2026 summer roadmap documentation

### Description of your changes

<!--

-->

- This PR adds new roadmap documentation for 2026 Summer (Date: 2026-04-01 to 2026-06-30)
- Added 2026-06-roadmap.md with planned features


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 2026 Summer roadmap page (docs/roadmap/2026-06-roadmap.md) for 2026-04-01 to 2026-06-30. It outlines plans for webhook-based config validation, type-safe config provider definitions, declarative addon management, and an addon ecosystem refresh.

<sup>Written for commit a50aac16eb61f85535c3213a63407a54621d1758. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



