### PR TITLE
docs: Add 2026 fall roadmap documentation

### DIFF
--- a/docs/roadmap/2026-09-roadmap.md
+++ b/docs/roadmap/2026-09-roadmap.md
@@ -1,0 +1,19 @@
+---
+title:  Roadmap 2026.09
+---
+
+Date: 2026-07-01 to 2026-09-30
+
+## Core Platform
+
+- Cluster Grouping for Policies
+  * Allow creating reusable cluster groups for multi-cluster deployments. 
+  * Define groups as collections of clusters or cluster label selectors. 
+  * Groups should be referenceable within existing Topology Policies to allow reusability and consistency across Applications.
+
+- Reusable Label Management
+  * Create labelsets using Config and ConfigTemplate for organizing governance data like teams, organizations, and cluster information. 
+  * LabelSets will be referenceable within Applications to better support governance requirements.
+
+- Crossplane credentials management
+  * Allow specifying cloud credentials for Crossplane integration via Kubernetes secrets.


### PR DESCRIPTION

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
- This PR adds new roadmap documentation for 2026 Fall (Date: 2026-07-01 to 2026-09-30
- Added 2026-09-roadmap.md with planned features


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 2026 Fall roadmap page (2026.09) outlining planned work for July 1–Sept 30, 2026. Covers cluster grouping for policies, reusable label sets via Config/ConfigTemplate, and Crossplane credentials via Kubernetes secrets.

<sup>Written for commit f21b7ceeac3e58ffbf826cf220e015340ec1bfbb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





