### PR TITLE
docs: Add 2026 winter roadmap documentation

### DIFF
--- a/docs/roadmap/2026-12-roadmap.md
+++ b/docs/roadmap/2026-12-roadmap.md
@@ -1,0 +1,18 @@
+---
+title:  Roadmap 2026.12
+---
+
+Date: 2026-10-01 to 2026-12-31
+
+## Core Platform
+
+- Namespace lifecycle management
+  * Resolve stale GroupVersion discovery issues when deleting namespaces in Gitops plugin scenarios. 
+  * This guarantees that deleting a namespace results in a complete and clean removal of all related KubeVela resources, preventing orphaned components.
+
+- Workflow debugging for external templates
+  * Support debugging workflows that reference external templates. 
+  * Currently, variables show as null when debugging workflows using workflow: ref.
+
+- Data passing between components
+  * Enable passing data from workload to traits without duplicate parameter definitions.


### PR DESCRIPTION


### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
- This PR adds new roadmap documentation for 2026 Winter (Date: 2026-10-01 to 2026-12-31)
- Added 2026-12-roadmap.md with planned features


I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 2026 Winter (Oct 1–Dec 31) roadmap documentation at docs/roadmap/2026-12-roadmap.md. It outlines plans for namespace lifecycle cleanup, workflow debugging for external templates, and passing data from workloads to traits without duplicate parameters.

<sup>Written for commit 48cd0da472e95d26f476fe953250c8e6f769be62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



