### PR TITLE
docs: Add 2026 quarterly roadmaps to v1.10 documentation

### DIFF
--- a/versioned_docs/version-v1.10/roadmap/2026-03-roadmap.md
+++ b/versioned_docs/version-v1.10/roadmap/2026-03-roadmap.md
@@ -1,0 +1,25 @@
+---
+title:  Roadmap 2026.03
+---
+
+Date: 2026-01-01 to 2026-03-31
+
+## Core Platform
+
+- Native Helm Chart Support
+  * Make Helm a first class citizen within KubeVela, adding native support through CueX and a supporting helmchart component. 
+  * This will allow KubeVela to deploy Helm Charts directly, without the need for external tools or addons like FluxCD and will use the existing KubeVela multi-cluster dispatch system for better awareness of the underlying managed resources within KubeVela. 
+- Definition Quality Improvements
+  * Review all definitions with focus on workflow steps. Validate definitions work in both Applications and WorkflowRuns. 
+  * Add test cases for each definition, ensure all definitions are working as intended and re-establish consistency between Applications and WorkflowRuns.
+- Testing Infrastructure Enhancement
+  * Improve E2E test suite for faster and more reliable releases. Add better test coverage and automation.
+
+
+## Best practices and community
+
+- Community Growth Program
+  * Create clear contributor guidelines and recognition system. 
+  * Add more examples to the repository showing real use cases. 
+  * Make it easier to contribute components and traits with better templates. 
+  * Remove outdated documentation and update examples to current versions.

--- a/versioned_docs/version-v1.10/roadmap/2026-06-roadmap.md
+++ b/versioned_docs/version-v1.10/roadmap/2026-06-roadmap.md
@@ -1,0 +1,24 @@
+---
+title:  Roadmap 2026.06
+---
+
+Date: 2026-04-01 to 2026-06-30
+
+## Core Platform
+
+- Config Validation via Webhooks
+  * Replace CLI validation with webhook-based approach to guarantee the integrity of configuration files and ensure that configuration cannot bypass validations. 
+  * This will ensure better integration with GitOps practices, reduce misconfiguration in deployments and enhance KubeVela configurations ability to act as a foundation for future enhancements.
+
+- Config Provider Definition
+  * Add support for validated and type safe definitions (via ConfigTemplates) for data/configuration retrieval. 
+  * This would support the existing definitions and allow for more dynamic configuration of Applications. 
+  * These definitions would be written in familiar cue syntax with CueX powering the ability to retrieve configuration from external systems and other resources. 
+
+- Declarative Addons
+  * Allow Addons to be installed and managed declaratively to better enable their usage within GitOps workflows.
+
+## Third-party integrations and addons
+
+- Addon Ecosystem Refresh
+  * Modernize and clean up the Addon catalog to ensure better stability and feature compatibility with the latest cloud and Kubernetes versions. 

--- a/versioned_docs/version-v1.10/roadmap/2026-09-roadmap.md
+++ b/versioned_docs/version-v1.10/roadmap/2026-09-roadmap.md
@@ -1,0 +1,19 @@
+---
+title:  Roadmap 2026.09
+---
+
+Date: 2026-07-01 to 2026-09-30
+
+## Core Platform
+
+- Cluster Grouping for Policies
+  * Allow creating reusable cluster groups for multi-cluster deployments. 
+  * Define groups as collections of clusters or cluster label selectors. 
+  * Groups should be referenceable within existing Topology Policies to allow reusability and consistency across Applications.
+
+- Reusable Label Management
+  * Create labelsets using Config and ConfigTemplate for organizing governance data like teams, organizations, and cluster information. 
+  * LabelSets will be referenceable within Applications to better support governance requirements.
+
+- Crossplane credentials management
+  * Allow specifying cloud credentials for Crossplane integration via Kubernetes secrets.

--- a/versioned_docs/version-v1.10/roadmap/2026-12-roadmap.md
+++ b/versioned_docs/version-v1.10/roadmap/2026-12-roadmap.md
@@ -1,0 +1,18 @@
+---
+title:  Roadmap 2026.12
+---
+
+Date: 2026-10-01 to 2026-12-31
+
+## Core Platform
+
+- Namespace lifecycle management
+  * Resolve stale GroupVersion discovery issues when deleting namespaces in Gitops plugin scenarios. 
+  * This guarantees that deleting a namespace results in a complete and clean removal of all related KubeVela resources, preventing orphaned components.
+
+- Workflow debugging for external templates
+  * Support debugging workflows that reference external templates. 
+  * Currently, variables show as null when debugging workflows using workflow: ref.
+
+- Data passing between components
+  * Enable passing data from workload to traits without duplicate parameter definitions.

--- a/versioned_docs/version-v1.10/roadmap/README.md
+++ b/versioned_docs/version-v1.10/roadmap/README.md
@@ -10,6 +10,11 @@ The goal of KubeVela is to **make deploying and operating applications across to
 
 They're aligned with the roadmap direction for the next three years. As for the detailed roadmap, we'll update and list below.
 
+- [2026 Winter Roadmap](./2026-12-roadmap)
+- [2026 Fall Roadmap](./2026-09-roadmap)
+- [2026 Summer Roadmap](./2026-06-roadmap)
+- [2026 Spring Roadmap](./2026-03-roadmap)
+- [2023 Summer Roadmap](./2023-06-roadmap)
 - [2023 Summer Roadmap](./2023-06-roadmap)
 - [2023 Spring Roadmap](./2023-03-roadmap)
 - [2022 Winter Roadmap](./2022-12-roadmap)

--- a/versioned_docs/version-v1.10/roadmap/README.md
+++ b/versioned_docs/version-v1.10/roadmap/README.md
@@ -15,7 +15,6 @@ They're aligned with the roadmap direction for the next three years. As for the 
 - [2026 Summer Roadmap](./2026-06-roadmap)
 - [2026 Spring Roadmap](./2026-03-roadmap)
 - [2023 Summer Roadmap](./2023-06-roadmap)
-- [2023 Summer Roadmap](./2023-06-roadmap)
 - [2023 Spring Roadmap](./2023-03-roadmap)
 - [2022 Winter Roadmap](./2022-12-roadmap)
 - [2022 Fall Roadmap](./2022-09-roadmap)


### PR DESCRIPTION
- Added 2026 Spring (March) roadmap
- Added 2026 Summer (June) roadmap
- Added 2026 Fall (September) roadmap
- Added 2026 Winter (December) roadmap
- Updated README.md to link to new roadmaps

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Update `sidebar.js` if adding a new page.
- [ ] Run `yarn start` to ensure the changes has taken effect.


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 2026 quarterly roadmap pages (Spring, Summer, Fall, Winter) to the v1.10 docs and update the roadmap index to link them. This keeps the v1.10 documentation current and gives users a clear view of planned work through 2026.

<sup>Written for commit ffc01b217f2a146712f7f8159a602f3efb24f96b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



